### PR TITLE
Added iwxxm-collect-codelists.sch with codelist Schematron rules

### DIFF
--- a/2.1.1RC1/rule/codes.wmo.int-49-2-AerodromePresentOrForecastWeather.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-AerodromePresentOrForecastWeather.rdf
@@ -1,0 +1,2044 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <reg:Register rdf:about="http://codes.wmo.int/49-2/AerodromePresentOrForecastWeather">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLDZRA">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZDZ">
+        <rdfs:label xml:lang="en">Precipitation of freezing drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLSGSN">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RADZSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGRSNRA">
+        <rdfs:label xml:lang="en">Showery precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNRAGS">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGRASN">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VA">
+        <rdfs:label xml:lang="en">Volcanic ash</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASGDZ">
+        <rdfs:label xml:lang="en">Precipitation of rain, snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:notation>D-7</skos:notation>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PL">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNGS">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-FZDZ">
+        <rdfs:label xml:lang="en">Light precipitation of freezing drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGR">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGSRASN">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNDZ">
+        <rdfs:label xml:lang="en">Light precipitation of snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNRA">
+        <rdfs:label xml:lang="en">Precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNGR">
+        <rdfs:label xml:lang="en">Showery precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PL">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZDZRA">
+        <rdfs:label xml:lang="en">Precipitation of freezing drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+FZRADZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of freezing rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASNDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGSN">
+        <rdfs:label xml:lang="en">Precipitation of snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASN">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRASNGS">
+        <rdfs:label xml:lang="en">Showery precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRASNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PRFG">
+        <rdfs:label xml:lang="en">Partial fog (covering part of the aerodrome)</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGS">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNSGPL">
+        <rdfs:label xml:lang="en">Precipitation of snow, snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGRSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZRASG">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RAPL">
+        <rdfs:label xml:lang="en">Precipitation of rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRASNGS">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGSSN">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZ">
+        <rdfs:label xml:lang="en">Precipitation of drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHUP">
+        <rdfs:label xml:lang="en">Light unidentified showery precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-FZDZRA">
+        <rdfs:label xml:lang="en">Light precipitation of freezing drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <dct:description xml:lang="en">The items within this code table are the weather phenomena that may be reported as forecast to occur or have been observed at an aerodrome. Requirements for reporting present or forecast weather at an aerodrome are specified in Technical Regulations, Volume II (WMO-No. 49), Part II, Appendix 3, [C.3.1.] 4.4 (observation), Appendix 5, [C.3.1] 2.2.4 (trend forecast) and [C.3.1.] 1.2.3 (for TAF).  The weather phenomena listed here are a subset of the enumerated set of meteorologically valid combinations specified in Part A, Code Table 4678 comprising elements ‘intensity or proximity’, ‘descriptor’, ‘precipitation’, ‘obscuration’ and/or ‘other’.</dct:description>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZRASN">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLDZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLRADZ">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SG">
+        <rdfs:label xml:lang="en">Precipitation of snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RADZSG">
+        <rdfs:label xml:lang="en">Precipitation of rain, drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGRRASN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCBLDU">
+        <rdfs:label xml:lang="en">Blowing dust in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNRAGR">
+        <rdfs:label xml:lang="en">Showery precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BR">
+        <rdfs:label xml:lang="en">Mist</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FU">
+        <rdfs:label xml:lang="en">Smoke</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNPLRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGPLSN">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGSSN">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-FZRA">
+        <rdfs:label xml:lang="en">Light precipitation of freezng rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RA">
+        <rdfs:label xml:lang="en">Light precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGDZRA">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+FZDZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of freezing drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-FZRADZ">
+        <rdfs:label xml:lang="en">Light precipitation of freezing rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZPL">
+        <rdfs:label xml:lang="en">Precipitation of drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRASNGR">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RADZSG">
+        <rdfs:label xml:lang="en">Light precipitation of rain, drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SG">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGRRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLSN">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNDZ">
+        <rdfs:label xml:lang="en">Precipitation of snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGRSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLRA">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGRSNRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BLSN">
+        <rdfs:label xml:lang="en">Blowing snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCBLSA">
+        <rdfs:label xml:lang="en">Blowing sand in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNPL">
+        <rdfs:label xml:lang="en">Light precipitation of snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGSNPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRAGS">
+        <rdfs:label xml:lang="en">Showery precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGDZ">
+        <rdfs:label xml:lang="en">Precipitation of snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGSNRA">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNRAGR">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZRASN">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGRRA">
+        <rdfs:label xml:lang="en">Showery precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZRAPL">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PO">
+        <rdfs:label xml:lang="en">Dust/sand whirls (dust devils)</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRAGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SN">
+        <rdfs:label xml:lang="en">Precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNSGPL">
+        <rdfs:label xml:lang="en">Light precipitation of snow, snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLSN">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZSGRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGRRASN">
+        <rdfs:label xml:lang="en">Light showery precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RADZSN">
+        <rdfs:label xml:lang="en">Precipitation of rain, drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLRA">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASG">
+        <rdfs:label xml:lang="en">Light precipitation of rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNGS">
+        <rdfs:label xml:lang="en">Showery precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGRRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGSNRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNSGRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RAPLSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+FZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of freezng rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGSSN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGRRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGSRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZRA">
+        <rdfs:label xml:lang="en">Precipitation of freezng rain</rdfs:label>
+        <rdfs:label xml:lang="en">Precipitation of freezing rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRAGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLDZRA">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGRADZ">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZSG">
+        <rdfs:label xml:lang="en">Precipitation of drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZRA">
+        <rdfs:label xml:lang="en">Precipitation of drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZ">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRASNGR">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RADZSN">
+        <rdfs:label xml:lang="en">Light precipitation of rain, drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RADZPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNRAGR">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow, rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNGSRA">
+        <rdfs:label xml:lang="en">Showery precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZPLRA">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DS">
+        <rdfs:label xml:lang="en">Heavy duststorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNSG">
+        <rdfs:label xml:lang="en">Light precipitation of snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASGDZ">
+        <rdfs:label xml:lang="en">Light precipitation of rain, snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RAPLSN">
+        <rdfs:label xml:lang="en">Precipitation of rain, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLDZ">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSUP">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZSG">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-FZUP">
+        <rdfs:label xml:lang="en">Light unidentified freezing precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNPL">
+        <rdfs:label xml:lang="en">Precipitation of snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRAGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-UP">
+        <rdfs:label xml:lang="en">Light unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNRAGS">
+        <rdfs:label xml:lang="en">Showery precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+UP">
+        <rdfs:label xml:lang="en">Heavy unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLSNRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGPL">
+        <rdfs:label xml:lang="en">Precipitation of snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RAPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASNPL">
+        <rdfs:label xml:lang="en">Precipitation of rain, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSN">
+        <rdfs:label xml:lang="en">Showery precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RADZ">
+        <rdfs:label xml:lang="en">Precipitation of rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGRRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNRADZ">
+        <rdfs:label xml:lang="en">Precipitation of snow, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRAGRSN">
+        <rdfs:label xml:lang="en">Showery precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SS">
+        <rdfs:label xml:lang="en">Sandstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DRSN">
+        <rdfs:label xml:lang="en">Low drifting snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGSN">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGDZ">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRASNGS">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGR">
+        <rdfs:label xml:lang="en">Showery precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASGSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLDZ">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGRASN">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGRSN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCFG">
+        <rdfs:label xml:lang="en">Fog in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRAGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RAPLDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZSNRA">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRAGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNRADZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHUP">
+        <rdfs:label xml:lang="en">Heavy unidentified showery precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/HZ">
+        <rdfs:label xml:lang="en">Haze</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SS">
+        <rdfs:label xml:lang="en">Heavy sandstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGSSNRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FG">
+        <rdfs:label xml:lang="en">Fog</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLRADZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNRA">
+        <rdfs:label xml:lang="en">Showery precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSNGRRA">
+        <rdfs:label xml:lang="en">Showery precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGPLSN">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLRASN">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASGSN">
+        <rdfs:label xml:lang="en">Precipitation of rain, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+FZUP">
+        <rdfs:label xml:lang="en">Heavy unidentified freezing precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCPO">
+        <rdfs:label xml:lang="en">Dust/sand whirls (dust devils) in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TS">
+        <rdfs:label xml:lang="en">Thunderstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLSNSG">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRAGRSN">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGDZRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLSNRA">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZUP">
+        <rdfs:label xml:lang="en">Unidentified freezing precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRASN">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DRSA">
+        <rdfs:label xml:lang="en">Low drifting sand</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNSG">
+        <rdfs:label xml:lang="en">Precipitation of snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RAPLDZ">
+        <rdfs:label xml:lang="en">Precipitation of rain, ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZSN">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZSNRA">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASNPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSN">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGRA">
+        <rdfs:label xml:lang="en">Precipitation of snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASG">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASNSG">
+        <rdfs:label xml:lang="en">Precipitation of rain, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCDS">
+        <rdfs:label xml:lang="en">Duststorm in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRAGR">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRASNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCFC">
+        <rdfs:label xml:lang="en">Funnel cloud(s) (tornado or water-spout) in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNGSRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGRRASN">
+        <rdfs:label xml:lang="en">Showery precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLSGSN">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNPLSG">
+        <rdfs:label xml:lang="en">Precipitation of snow, ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRAGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNPLRA">
+        <rdfs:label xml:lang="en">Precipitation of snow, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZRAPL">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRASN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNRAPL">
+        <rdfs:label xml:lang="en">Precipitation of snow, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGSSNRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DS">
+        <rdfs:label xml:lang="en">Duststorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGSRA">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNRAGS">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow, rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FC">
+        <rdfs:label xml:lang="en">Funnel cloud(s) (tornado or water-spout)</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNDZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNRADZ">
+        <rdfs:label xml:lang="en">Light precipitation of snow, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRAGRSN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain, hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PL">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RADZPL">
+        <rdfs:label xml:lang="en">Precipitation of rain, drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNGR">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRAGR">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRAGS">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNSGPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNPLSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCSH">
+        <rdfs:label xml:lang="en">Shower(s) in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGSRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGRRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SG">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNRAPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLRADZ">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGRADZ">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRASNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZSNRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCSS">
+        <rdfs:label xml:lang="en">Sandstorm in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASNSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSUP">
+        <rdfs:label xml:lang="en">Thunderstorm with light unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RADZPL">
+        <rdfs:label xml:lang="en">Light precipitation of rain, drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLSG">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZPLRA">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGS">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSSNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RAPLSN">
+        <rdfs:label xml:lang="en">Light precipitation of rain, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNGRRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSUP">
+        <rdfs:label xml:lang="en">Thunderstorm with unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNGRRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASNDZ">
+        <rdfs:label xml:lang="en">Precipitation of rain, snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNSGRA">
+        <rdfs:label xml:lang="en">Precipitation of snow, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSNGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGSNPL">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASG">
+        <rdfs:label xml:lang="en">Precipitation of rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNRASG">
+        <rdfs:label xml:lang="en">Precipitation of snow, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASNPL">
+        <rdfs:label xml:lang="en">Light precipitation of rain, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DRDU">
+        <rdfs:label xml:lang="en">Low drifting dust</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCBLSN">
+        <rdfs:label xml:lang="en">Blowing snow in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRAGSSN">
+        <rdfs:label xml:lang="en">Showery precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGPL">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCVA">
+        <rdfs:label xml:lang="en">Volcanic ash in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLSG">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >2</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VCTS">
+        <rdfs:label xml:lang="en">Thunderstorm in the vicinity</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RA">
+        <rdfs:label xml:lang="en">Precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGPLSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, ice pellets and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNPLSG">
+        <rdfs:label xml:lang="en">Light precipitation of snow, ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNPLRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:52:40.633Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RAPL">
+        <rdfs:label xml:lang="en">Light precipitation of rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZPLRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNRAPL">
+        <rdfs:label xml:lang="en">Light precipitation of snow, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGSNPL">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains, snow and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BLSA">
+        <rdfs:label xml:lang="en">Blowing sand</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZRAPL">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, rain and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGSRASN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SNRASG">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGR">
+        <rdfs:label xml:lang="en">Light showery precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SGRASN">
+        <rdfs:label xml:lang="en">Precipitation of snow grains, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRAGS">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SN">
+        <rdfs:label xml:lang="en">Light precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRAGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSRASNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SNDZRA">
+        <rdfs:label xml:lang="en">Precipitation of snow, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SN">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RA">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASGSN">
+        <rdfs:label xml:lang="en">Light precipitation of rain, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGR">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGRSNRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZFG">
+        <rdfs:label xml:lang="en">Freezing fog</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGRSNRA">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RAPLDZ">
+        <rdfs:label xml:lang="en">Light precipitation of rain, ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SA">
+        <rdfs:label xml:lang="en">Sand</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZPL">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle and ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNGS">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRAGS">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLSNSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZRASG">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGRSN">
+        <rdfs:label xml:lang="en">Showery precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RASN">
+        <rdfs:label xml:lang="en">Precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASNSG">
+        <rdfs:label xml:lang="en">Light precipitation of rain, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRA">
+        <rdfs:label xml:lang="en">Showery precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNGR">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLSGSN">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, snow grains and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SGRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNSGRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSRASNGS">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of rain, snow and snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-TSGS">
+        <rdfs:label xml:lang="en">Thunderstorm with light precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGSRASN">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASN">
+        <rdfs:label xml:lang="en">Light precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNRASG">
+        <rdfs:label xml:lang="en">Light precipitation of snow, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRASNGR">
+        <rdfs:label xml:lang="en">Showery precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGRSN">
+        <rdfs:label xml:lang="en">Light showery precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+FZDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of freezing drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRASNGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain, snow and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGR">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHRAGSSN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+PLRASN">
+        <rdfs:label xml:lang="en">Heavy precipitation of ice pellets, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZSN">
+        <rdfs:label xml:lang="en">Precipitation of drizzle and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RADZSG">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, drizzle and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/UP">
+        <rdfs:label xml:lang="en">Unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZRADZ">
+        <rdfs:label xml:lang="en">Precipitation of freezing rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZSGRA">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BCFG">
+        <rdfs:label xml:lang="en">Patches of fog</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGSSNRA">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/MIFG">
+        <rdfs:label xml:lang="en">Shallow fog</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGSNRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRAGSSN">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain, snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZRA">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGDZRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SNDZRA">
+        <rdfs:label xml:lang="en">Light precipitation of snow, drizzle and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGRSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-DZSGRA">
+        <rdfs:label xml:lang="en">Light precipitation of drizzle, snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZRASN">
+        <rdfs:label xml:lang="en">Precipitation of drizzle, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SQ">
+        <rdfs:label xml:lang="en">Squalls</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>Code Table D-7: Aerodrome present or forecast weather</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHSNGSRA">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow, snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SHGSRASN">
+        <rdfs:label xml:lang="en">Heavy showery precipitation of snow pellets/small hail, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RASNDZ">
+        <rdfs:label xml:lang="en">Light precipitation of rain, snow and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RADZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLSNSG">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, snow and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHGS">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PLSNRA">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets, snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRASN">
+        <rdfs:label xml:lang="en">Showery precipitation of rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGRA">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BLDU">
+        <rdfs:label xml:lang="en">Blowing dust</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-SHSNRA">
+        <rdfs:label xml:lang="en">Light showery precipitation of snow and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSNGRRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow, hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail and rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-PLRASN">
+        <rdfs:label xml:lang="en">Light precipitation of ice pellets, rain and snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+DZRASG">
+        <rdfs:label xml:lang="en">Heavy precipitation of drizzle, rain and snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+TSGS">
+        <rdfs:label xml:lang="en">Thunderstorm with heavy precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+RASGDZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of rain, snow grains and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/-RADZ">
+        <rdfs:label xml:lang="en">Light precipitation of rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHUP">
+        <rdfs:label xml:lang="en">Unidentified showery precipitation</rdfs:label>
+        <rdfs:label xml:lang="en">Showery precipitation of unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DU">
+        <rdfs:label xml:lang="en">Dust</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/+SGRADZ">
+        <rdfs:label xml:lang="en">Heavy precipitation of snow grains, rain and drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRAGR">
+        <rdfs:label xml:lang="en">Showery precipitation of rain and hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+  </reg:Register>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-AerodromeRecentWeather.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-AerodromeRecentWeather.rdf
@@ -1,0 +1,174 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/49-2/AerodromeRecentWeather">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSSN">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSUP">
+        <rdfs:label xml:lang="en">Thunderstorm with unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHUP">
+        <rdfs:label xml:lang="en">Unidentified showery precipitation</rdfs:label>
+        <rdfs:label xml:lang="en">Showery precipitation of unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DS">
+        <rdfs:label xml:lang="en">Duststorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:notation>D-6</skos:notation>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FC">
+        <rdfs:label xml:lang="en">Funnel cloud(s) (tornado or water-spout)</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>Code Table D-6: Aerodrome recent weather</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/VA">
+        <rdfs:label xml:lang="en">Volcanic ash</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZRA">
+        <rdfs:label xml:lang="en">Precipitation of freezng rain</rdfs:label>
+        <rdfs:label xml:lang="en">Precipitation of freezing rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/BLSN">
+        <rdfs:label xml:lang="en">Blowing snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGR">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHSN">
+        <rdfs:label xml:lang="en">Showery precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGR">
+        <rdfs:label xml:lang="en">Showery precipitation of hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/RA">
+        <rdfs:label xml:lang="en">Precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/PL">
+        <rdfs:label xml:lang="en">Precipitation of ice pellets</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SG">
+        <rdfs:label xml:lang="en">Precipitation of snow grains</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:52:41.1Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSGS">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZDZ">
+        <rdfs:label xml:lang="en">Precipitation of freezing drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >2</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TSRA">
+        <rdfs:label xml:lang="en">Thunderstorm with precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/UP">
+        <rdfs:label xml:lang="en">Unidentified precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/TS">
+        <rdfs:label xml:lang="en">Thunderstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/DZ">
+        <rdfs:label xml:lang="en">Precipitation of drizzle</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SN">
+        <rdfs:label xml:lang="en">Precipitation of snow</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/FZUP">
+        <rdfs:label xml:lang="en">Unidentified freezing precipitation</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHRA">
+        <rdfs:label xml:lang="en">Showery precipitation of rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SS">
+        <rdfs:label xml:lang="en">Sandstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <dct:description xml:lang="en">The items within this code table are the weather types that may be reported within a meteorological aerodrome observation report that have occurred during the period since the last issued routine report or last hour, whichever is shorter, but are not observed at the time of the observation. Requirements for reporting recent weather at an aerodrome are specified in Technical Regulations, Volume II (WMO-No. 49), Part II, Appendix 3, [C.3.1.] 4.8.1.1.  This code table contains the set of weather types that are permitted for reporting recent weather. These are a subset of the enumerated set of meteorologically valid combinations specified in Part A, Code Table 4678 comprising elements ‘intensity or proximity’, ‘descriptor’, ‘precipitation’, ‘obscuration’ and/or ‘other’.</dct:description>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/306/4678/SHGS">
+        <rdfs:label xml:lang="en">Showery precipitation of snow pellets/small hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-AirWxPhenomena.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-AirWxPhenomena.rdf
@@ -1,0 +1,170 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <reg:Register rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/OCNL_TCU">
+        <dct:description xml:lang="en">Occasional towering cumulus cloud</dct:description>
+        <rdfs:label xml:lang="en">Occasional towering cumulus cloud</rdfs:label>
+        <skos:notation>OCNL TCU</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/OCNL_CB">
+        <dct:description xml:lang="en">Occasional cumulonimbus cloud</dct:description>
+        <rdfs:label xml:lang="en">Occasional cumulonimbus cloud</rdfs:label>
+        <skos:notation>OCNL CB</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/ISOL_CB">
+        <dct:description xml:lang="en">Isolated cumulonimbus cloud</dct:description>
+        <rdfs:label xml:lang="en">Isolated cumulonimbus cloud</rdfs:label>
+        <skos:notation>ISOL CB</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <dct:description xml:lang="en">ICAO Annex 3/ WMO No. 49-2 Appendix 6 Section 2.1</dct:description>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/MOD_ICE">
+        <dct:description xml:lang="en">Moderate icing</dct:description>
+        <rdfs:label xml:lang="en">Moderate icing</rdfs:label>
+        <skos:notation>MOD ICE</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/BKN_CLD">
+        <dct:description xml:lang="en">Broken cloud</dct:description>
+        <rdfs:label xml:lang="en">Broken cloud</rdfs:label>
+        <skos:notation>BKN CLD</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label xml:lang="en">Air Wx Phenomena</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/SFC_WIND">
+        <dct:description xml:lang="en">Widespread mean surface wind</dct:description>
+        <rdfs:label xml:lang="en">Widespread mean surface wind</rdfs:label>
+        <skos:notation>SFC WIND nn[n]MPS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/MT_OBSC">
+        <dct:description xml:lang="en">Mountain obscuration</dct:description>
+        <rdfs:label xml:lang="en">Mountain obscuration</rdfs:label>
+        <skos:notation>MT OBSC</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/SFC_VIS">
+        <dct:description xml:lang="en">Surface visibility</dct:description>
+        <rdfs:label xml:lang="en">Surface visibility</rdfs:label>
+        <skos:notation>SFC VIS nnnnM (mm)</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/FRQ_CB">
+        <dct:description xml:lang="en">Frequent cumulonimbus cloud</dct:description>
+        <rdfs:label xml:lang="en">Frequent cumulonimbus cloud</rdfs:label>
+        <skos:notation>FRQ CB</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/OCNL_TS">
+        <dct:description xml:lang="en">Occasional thunderstorms</dct:description>
+        <rdfs:label>Occasional thunderstorms</rdfs:label>
+        <skos:notation xml:lang="en">OCNL TS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2016-12-30T13:26:05.884Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/FRQ_TCU">
+        <dct:description xml:lang="en">Frequent towering cumulus cloud</dct:description>
+        <rdfs:label xml:lang="en">Frequent towering cumulus cloud</rdfs:label>
+        <skos:notation>FRQ TCU</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/OVC_CLD">
+        <dct:description xml:lang="en">Overcast cloud</dct:description>
+        <rdfs:label xml:lang="en">Overcast cloud</rdfs:label>
+        <skos:notation>OVC CLD</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/ISOL_TCU">
+        <dct:description xml:lang="en">Isolated towering cumulus cloud</dct:description>
+        <rdfs:label xml:lang="en">Isolated towering cumulus cloud</rdfs:label>
+        <skos:notation>ISOL TCU</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <ldp:hasMemberRelation rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/MOD_MTW">
+        <dct:description xml:lang="en">Moderate mountain wave</dct:description>
+        <rdfs:label xml:lang="en">Moderate mountain wave</rdfs:label>
+        <skos:notation>MOD MTW</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/MOD_TURB">
+        <dct:description xml:lang="en">Moderate turbulence</dct:description>
+        <rdfs:label xml:lang="en">Moderate turbulence</rdfs:label>
+        <skos:notation>MOD TURB</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/ISOL_TSGR">
+        <dct:description xml:lang="en">Isolated thunderstorms with hail</dct:description>
+        <rdfs:label xml:lang="en">Isolated thunderstorms with hail</rdfs:label>
+        <skos:notation>ISOL TSGR</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/ISOL_TS">
+        <dct:description xml:lang="en">Isolated thunderstorms</dct:description>
+        <rdfs:label xml:lang="en">Isolated thunderstorms</rdfs:label>
+        <skos:notation>ISOL TS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AirWxPhenomena/OCNL_TSGR">
+        <dct:description xml:lang="en">Occasional thunderstorms with hail</dct:description>
+        <rdfs:label xml:lang="en">Occasional thunderstorms with hail</rdfs:label>
+        <skos:notation>OCNL TSGR</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+  </reg:Register>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-AviationColourCode.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-AviationColourCode.rdf
@@ -1,0 +1,93 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/49-2/AviationColourCode">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/NOT_GIVEN">
+        <dct:description xml:lang="en">Not Given</dct:description>
+        <rdfs:label xml:lang="en">Not Given</rdfs:label>
+        <skos:notation>NOT GIVEN</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/UNKNOWN">
+        <dct:description xml:lang="en">Unknown</dct:description>
+        <rdfs:label xml:lang="en">Unknown</rdfs:label>
+        <skos:notation>UNKNOWN</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/YELLOW">
+        <dct:description xml:lang="en">Volcano is experiencing signs of elevated unrest above known background levels. Or, after a change from higher alert level: Volcanic activity has decreased significantly but continues to be closely monitored for possible renewed increase.</dct:description>
+        <rdfs:label xml:lang="en">Yellow</rdfs:label>
+        <skos:notation>YELLOW</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2016-12-30T13:26:16.18Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/RED">
+        <dct:description xml:lang="en">Eruption is forecasted to be imminent with significant emission of ash into the atmosphere likely. Or, eruption is underway with significant emission of ash into the atmosphere [specify ash-plume height if possible].</dct:description>
+        <rdfs:label xml:lang="en">Red</rdfs:label>
+        <skos:notation>RED</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/NIL">
+        <dct:description xml:lang="en">Nil</dct:description>
+        <rdfs:label xml:lang="en">Nil</rdfs:label>
+        <skos:notation>NIL</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/ORANGE">
+        <dct:description xml:lang="en">Volcano is exhibiting heightened unrest with increased likelihood of eruption.  Or, volcanic eruption is underway with no or minor ash emission [specify ash-plume height if possible].</dct:description>
+        <rdfs:label xml:lang="en">Orange</rdfs:label>
+        <skos:notation>ORANGE</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <ldp:hasMemberRelation rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <dct:description xml:lang="en">Volcanic Aviation Colour Code ICAO Annex 15</dct:description>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/AviationColourCode/GREEN">
+        <dct:description xml:lang="en">Volcano is in normal, non-eruptive state.  Or, after a change from a higher alert level: Volcanic activity considered to have ceased, and volcano reverted to its normal, non-eruptive state.</dct:description>
+        <rdfs:label xml:lang="en">Green</rdfs:label>
+        <skos:notation>GREEN</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label xml:lang="en">Volcanic Aviation Colour Code</rdfs:label>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-CloudAmountReportedAtAerodrome.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-CloudAmountReportedAtAerodrome.rdf
@@ -1,0 +1,153 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:j.0="http://codes.wmo.int/common/c-15/ae/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.1="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/49-2/CloudAmountReportedAtAerodrome">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/14">
+        <dct:description xml:lang="en">Layers. Applicable only to cumulonimbus (CB).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Layers</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >14</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/8">
+        <dct:description xml:lang="en">Isolated. Applicable only to cumulonimbus (CB).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Isolated</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >8</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+        <skos:note xml:lang="en">(Used on aviation charts to describe the cloud type Cb)</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/12">
+        <dct:description xml:lang="en">Frequent. Applicable only to cumulonimbus (CB).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Frequent</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >12</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+        <skos:note xml:lang="en">(Used on aviation charts to describe the cloud type Cb)</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:notation>D-8</skos:notation>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/3">
+        <dct:description xml:lang="en">Broken (5 - 7 oktas).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Broken</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >3</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/10">
+        <dct:description xml:lang="en">Occasional. Applicable only to cumulonimbus (CB).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Occasional</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >10</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+        <skos:note xml:lang="en">(Used on aviation charts to describe the cloud type Cb)</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:52:41.911Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/4">
+        <dct:description xml:lang="en">Overcast (8 oktas).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Overcast</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >4</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/1">
+        <dct:description xml:lang="en">Few (1 - 2 oktas).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Few</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >1</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/2">
+        <dct:description xml:lang="en">Scattered (3 - 4 oktas).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Scattered</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >2</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <rdfs:label>Code Table D-8: Cloud amount reported at aerodrome</rdfs:label>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/0">
+        <dct:description xml:lang="en">Sky clear (0 oktas).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Sky clear</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >0</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-008/16">
+        <dct:description xml:lang="en">Embedded. Applicable only to cumulonimbus (CB).</dct:description>
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/ae/cloudDistributionForAviation"/>
+        <rdfs:label xml:lang="en">Embedded</rdfs:label>
+        <rdfs:label xml:lang="en">Embedded (EMBD)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >16</skos:notation>
+        <j.1:fxy>020008</j.1:fxy>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >3</owl:versionInfo>
+    <dct:description xml:lang="en">The items within this code table are the cloud amount categories of operational significance for aviation as specified in Technical Regulations, Volume II (WMO-No. 49): Meteorological Services for International Air Navigation. This code table contains a subset of the cloud amount categories defined in Part B FM 94 BUFR Code Table 0 20 008.</dct:description>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-SigConvectiveCloudType.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-SigConvectiveCloudType.rdf
@@ -1,0 +1,69 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:j.1="http://codes.wmo.int/common/c-15/me/"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/49-2/SigConvectiveCloudType">
+    <rdfs:label>Code Table D-9: Significant convective cloud type</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-012/9">
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/me/cloudType"/>
+        <rdfs:label xml:lang="en">Cumulonimbus</rdfs:label>
+        <rdfs:label xml:lang="en">Cumulonimbus (Cb)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >9</skos:notation>
+        <j.0:fxy>020012</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <dct:description xml:lang="en">The items within this code table are the cloud types of operational significance for aviation as specified in Technical Regulations, Volume II (WMO-No. 49): Meteorological Services for International Air Navigation. This code table contains a subset of the cloud types defined in Part B FM 94 BUFR Code Table 0 20 012.</dct:description>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >2</owl:versionInfo>
+    <skos:notation>D-9</skos:notation>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:52:41.998Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-012/32">
+        <rdf:type rdf:resource="http://codes.wmo.int/common/c-15/me/cloudType"/>
+        <rdfs:label xml:lang="en">Towering cumulus</rdfs:label>
+        <rdfs:label xml:lang="en">Cumulus mediocris or congestus, Towering cumulus (TCU), with or without Cumulus of species fractus or humilis or Stratocumulus, all having their bases at the same level</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >32</skos:notation>
+        <j.0:fxy>020012</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-SigWxPhenomena.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-SigWxPhenomena.rdf
@@ -1,0 +1,132 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <reg:Register rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/RDOACT_CLD">
+        <rdfs:label xml:lang="en">Radioactive cloud</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <rdfs:label>Code Table D-10: Significant Weather Phenomena</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SEV_TURB">
+        <rdfs:label xml:lang="en">Severe turbulence</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SEV_MTW">
+        <rdfs:label xml:lang="en">Severe mountain wave</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SEV_ICE_FZRA">
+        <rdfs:label xml:lang="en">Severe airframe icing from freezing rain</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/OBSC_TSGR">
+        <rdfs:label xml:lang="en">Obscured thunderstorm with hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/TC">
+        <rdfs:label xml:lang="en">Tropical cyclone</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >2</owl:versionInfo>
+    <dct:description xml:lang="en">The items within this code table are the types of weather phenomena of significance to aeronautical operations – as used in SIGMET and AIRMET reports and specified in Technical Regulations, Volume II (WMO-No. 49), Part II, Appendix 6, [C.3.1.] 1.1.4. </dct:description>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SQL_TS">
+        <rdfs:label xml:lang="en">Squall line</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SQL_TSGR">
+        <rdfs:label xml:lang="en">Squall line with hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/FRQ_TS">
+        <rdfs:label xml:lang="en">Frequent thunderstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:52:41.384Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/OBSC_TS">
+        <rdfs:label xml:lang="en">Obscured thunderstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/VA">
+        <rdfs:label xml:lang="en">Volcanic ash</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/FRQ_TSGR">
+        <rdfs:label xml:lang="en">Frequent thunderstorm with hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/HVY_DS">
+        <rdfs:label xml:lang="en">Heavy dust storm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/SEV_ICE">
+        <rdfs:label xml:lang="en">Severe airframe icing</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/HVY_SS">
+        <rdfs:label xml:lang="en">Heavy sand storm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/EMBD_TSGR">
+        <rdfs:label xml:lang="en">Embedded thunderstorm with hail</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/SigWxPhenomena/EMBD_TS">
+        <rdfs:label xml:lang="en">Embedded thunderstorm</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:notation>D-10</skos:notation>
+  </reg:Register>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-49-2-WeatherCausingVisibilityReduction.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-49-2-WeatherCausingVisibilityReduction.rdf
@@ -1,0 +1,177 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/SQ">
+        <dct:description xml:lang="en">Squall</dct:description>
+        <rdfs:label xml:lang="en">Squall</rdfs:label>
+        <skos:notation>SQ</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/GS">
+        <dct:description xml:lang="en">Small Hail</dct:description>
+        <rdfs:label xml:lang="en">Small Hail</rdfs:label>
+        <skos:notation>GS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/BR">
+        <dct:description xml:lang="en">Mist</dct:description>
+        <rdfs:label xml:lang="en">Mist</rdfs:label>
+        <skos:notation>BR</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/VA">
+        <dct:description xml:lang="en">Volcanic Ash</dct:description>
+        <rdfs:label xml:lang="en">Volcanic Ash</rdfs:label>
+        <skos:notation>VA</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/SA">
+        <dct:description xml:lang="en">Sand</dct:description>
+        <rdfs:label xml:lang="en">Sand</rdfs:label>
+        <skos:notation>SA</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label xml:lang="en">Weather Causing Visibility Reduction</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/HZ">
+        <dct:description xml:lang="en">Haze</dct:description>
+        <rdfs:label xml:lang="en">Haze</rdfs:label>
+        <skos:notation>HZ</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/DU">
+        <dct:description xml:lang="en">Dust</dct:description>
+        <rdfs:label xml:lang="en">Dust</rdfs:label>
+        <skos:notation>DU</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/SS">
+        <dct:description xml:lang="en">Sandstorm</dct:description>
+        <rdfs:label xml:lang="en">Sandstorm</rdfs:label>
+        <skos:notation>SS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <ldp:hasMemberRelation rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/DZ">
+        <dct:description xml:lang="en">Drizzle</dct:description>
+        <rdfs:label xml:lang="en">Drizzle</rdfs:label>
+        <skos:notation>DZ</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/FU">
+        <dct:description xml:lang="en">Smoke</dct:description>
+        <rdfs:label xml:lang="en">Smoke</rdfs:label>
+        <skos:notation>FU</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/SG">
+        <dct:description xml:lang="en">Snow grams</dct:description>
+        <rdfs:label xml:lang="en">Snow grams</rdfs:label>
+        <skos:notation>SG</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/PL">
+        <dct:description xml:lang="en">Ice pellets</dct:description>
+        <rdfs:label xml:lang="en">Ice pellets</rdfs:label>
+        <skos:notation>PL</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/RA">
+        <dct:description xml:lang="en">Rain</dct:description>
+        <rdfs:label xml:lang="en">Rain</rdfs:label>
+        <skos:notation>RA</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/FG">
+        <dct:description xml:lang="en">Fog</dct:description>
+        <rdfs:label xml:lang="en">Fog</rdfs:label>
+        <skos:notation>FG</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/SN">
+        <dct:description xml:lang="en">Snow</dct:description>
+        <rdfs:label xml:lang="en">Snow</rdfs:label>
+        <skos:notation>SN</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2016-12-30T13:26:25.95Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/PO">
+        <dct:description xml:lang="en">Dust/stand whirls</dct:description>
+        <rdfs:label xml:lang="en">Dust/stand whirls</rdfs:label>
+        <skos:notation>PO</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <dct:description xml:lang="en">ICAO Annex 3/ WMO No. 49-2 Appendix 6 Section 2.1 under SFC VIS</dct:description>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/DS">
+        <dct:description xml:lang="en">Duststorm</dct:description>
+        <rdfs:label xml:lang="en">Duststorm</rdfs:label>
+        <skos:notation>DS</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/FC">
+        <dct:description xml:lang="en">Funnel Cloud</dct:description>
+        <rdfs:label xml:lang="en">Funnel Cloud</rdfs:label>
+        <skos:notation>FC</skos:notation>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction/GR">
+        <dct:description xml:lang="en">Hail</dct:description>
+        <rdfs:label xml:lang="en">Hail</rdfs:label>
+        <skos:notation>GR</skos:notation>
+      </skos:Concept>
+    </skos:member>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-086.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-086.rdf
@@ -1,0 +1,138 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/7">
+        <rdfs:label xml:lang="en">Ice</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >7</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:54:57.683Z</dct:modified>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/8">
+        <rdfs:label xml:lang="en">Compacted or rolled snow</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >8</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/1">
+        <rdfs:label xml:lang="en">Damp</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >1</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/2">
+        <rdfs:label xml:lang="en">Wet with water patches</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >2</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>Runway deposits</rdfs:label>
+    <dct:publisher rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/0">
+        <rdfs:label xml:lang="en">Clear and dry</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >0</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/5">
+        <rdfs:label xml:lang="en">Wet snow</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >5</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/6">
+        <dct:description xml:lang="en">Snow or ice on the ground that has been reduced to a soft watery mixture by rain, warm temperature, and/or chemical treatment.</dct:description>
+        <dct:description xml:lang="fr">Neige ou de glace sur le sol qui a été réduite à un doux mélange aqueux par la pluie, la température chaude et / ou le traitement chimique.</dct:description>
+        <rdfs:label xml:lang="en">Slush</rdfs:label>
+        <rdfs:label xml:lang="fr">Neige fondante</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >6</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/15">
+        <rdfs:label xml:lang="en">Missing or not reported (e.g. due to runway clearance in progress)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >15</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/3">
+        <rdfs:label xml:lang="en">Rime and frost covered (depth normally less than 1 mm)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >3</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/4">
+        <rdfs:label xml:lang="en">Dry snow</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >4</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-086/9">
+        <rdfs:label xml:lang="en">Frozen ruts or ridges</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >9</skos:notation>
+        <j.0:fxy>020086</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-087.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-087.rdf
@@ -1,0 +1,87 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <reg:Register rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087">
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087/15">
+        <rdfs:label xml:lang="en">Missing or not reported (e.g. due to runway clearance in progress)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >15</skos:notation>
+        <j.0:fxy>020087</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>Runway contamination</rdfs:label>
+    <dct:publisher rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087/1">
+        <rdfs:label xml:lang="en">Less than 10% of runway covered</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >1</skos:notation>
+        <j.0:fxy>020087</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087/9">
+        <rdfs:label xml:lang="en">51% to 100% of runway covered</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >9</skos:notation>
+        <j.0:fxy>020087</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:54:58.449Z</dct:modified>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087/5">
+        <rdfs:label xml:lang="en">25% to 50% of runway covered</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >5</skos:notation>
+        <j.0:fxy>020087</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-087/2">
+        <rdfs:label xml:lang="en">11% to 25% of runway covered</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >2</skos:notation>
+        <j.0:fxy>020087</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+  </reg:Register>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-089.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-20-089.rdf
@@ -1,0 +1,855 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <reg:Register rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/36">
+        <rdfs:label xml:lang="en">0.36</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >36</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/98">
+        <rdfs:label xml:lang="en">0.98</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >98</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/89">
+        <rdfs:label xml:lang="en">0.89</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >89</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/11">
+        <rdfs:label xml:lang="en">0.11</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >11</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/41">
+        <rdfs:label xml:lang="en">0.41</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >41</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>Runway friction coefficient</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/95">
+        <rdfs:label xml:lang="en">Braking action good</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >95</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/27">
+        <rdfs:label xml:lang="en">0.27</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >27</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/37">
+        <rdfs:label xml:lang="en">0.37</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >37</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/48">
+        <rdfs:label xml:lang="en">0.48</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >48</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/82">
+        <rdfs:label xml:lang="en">0.82</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >82</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/66">
+        <rdfs:label xml:lang="en">0.66</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >66</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/9">
+        <rdfs:label xml:lang="en">0.09</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >9</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/99">
+        <rdfs:label xml:lang="en">Unreliable</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >99</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/65">
+        <rdfs:label xml:lang="en">0.65</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >65</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/52">
+        <rdfs:label xml:lang="en">0.52</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >52</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/0">
+        <rdfs:label xml:lang="en">0.00</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >0</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/13">
+        <rdfs:label xml:lang="en">0.13</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >13</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/70">
+        <rdfs:label xml:lang="en">0.70</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >70</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/80">
+        <rdfs:label xml:lang="en">0.80</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >80</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/31">
+        <rdfs:label xml:lang="en">0.31</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >31</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/58">
+        <rdfs:label xml:lang="en">0.58</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >58</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/68">
+        <rdfs:label xml:lang="en">0.68</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >68</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/86">
+        <rdfs:label xml:lang="en">0.86</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >86</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/73">
+        <rdfs:label xml:lang="en">0.73</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >73</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/59">
+        <rdfs:label xml:lang="en">0.59</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >59</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/72">
+        <rdfs:label xml:lang="en">0.72</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >72</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/56">
+        <rdfs:label xml:lang="en">0.56</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >56</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/22">
+        <rdfs:label xml:lang="en">0.22</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >22</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/38">
+        <rdfs:label xml:lang="en">0.38</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >38</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/4">
+        <rdfs:label xml:lang="en">0.04</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >4</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/17">
+        <rdfs:label xml:lang="en">0.17</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >17</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/79">
+        <rdfs:label xml:lang="en">0.79</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >79</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/21">
+        <rdfs:label xml:lang="en">0.21</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >21</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/76">
+        <rdfs:label xml:lang="en">0.76</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >76</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/96">
+        <rdfs:label xml:lang="en">0.96</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >96</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/63">
+        <rdfs:label xml:lang="en">0.63</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >63</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/14">
+        <rdfs:label xml:lang="en">0.14</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >14</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/24">
+        <rdfs:label xml:lang="en">0.24</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >24</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/81">
+        <rdfs:label xml:lang="en">0.81</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >81</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/49">
+        <rdfs:label xml:lang="en">0.49</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >49</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/42">
+        <rdfs:label xml:lang="en">0.42</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >42</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/67">
+        <rdfs:label xml:lang="en">0.67</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >67</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/77">
+        <rdfs:label xml:lang="en">0.77</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >77</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/2">
+        <rdfs:label xml:lang="en">0.02</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >2</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/15">
+        <rdfs:label xml:lang="en">0.15</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >15</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/127">
+        <rdfs:label xml:lang="en">Missing, not reported and/or runway not operational</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >127</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/12">
+        <rdfs:label xml:lang="en">0.12</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >12</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/1">
+        <rdfs:label xml:lang="en">0.01</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >1</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/90">
+        <rdfs:label xml:lang="en">0.90</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >90</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/53">
+        <rdfs:label xml:lang="en">0.53</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >53</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/83">
+        <rdfs:label xml:lang="en">0.83</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >83</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/69">
+        <rdfs:label xml:lang="en">0.69</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >69</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/87">
+        <rdfs:label xml:lang="en">0.87</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >87</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/93">
+        <rdfs:label xml:lang="en">Braking action medium</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >93</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/74">
+        <rdfs:label xml:lang="en">0.74</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >74</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/84">
+        <rdfs:label xml:lang="en">0.84</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >84</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/35">
+        <rdfs:label xml:lang="en">0.35</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >35</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/46">
+        <rdfs:label xml:lang="en">0.46</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >46</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/18">
+        <rdfs:label xml:lang="en">0.18</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >18</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/28">
+        <rdfs:label xml:lang="en">0.28</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >28</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/32">
+        <rdfs:label xml:lang="en">0.32</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >32</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/6">
+        <rdfs:label xml:lang="en">0.06</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >6</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/19">
+        <rdfs:label xml:lang="en">0.19</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >19</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/91">
+        <rdfs:label xml:lang="en">Braking action poor</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >91</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/60">
+        <rdfs:label xml:lang="en">0.60</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >60</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/50">
+        <rdfs:label xml:lang="en">0.50</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >50</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/23">
+        <rdfs:label xml:lang="en">0.23</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >23</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/33">
+        <rdfs:label xml:lang="en">0.33</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >33</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/44">
+        <rdfs:label xml:lang="en">0.44</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >44</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:54:58.855Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/5">
+        <rdfs:label xml:lang="en">0.05</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >5</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/78">
+        <rdfs:label xml:lang="en">0.78</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >78</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/88">
+        <rdfs:label xml:lang="en">0.88</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >88</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/26">
+        <rdfs:label xml:lang="en">0.26</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >26</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/8">
+        <rdfs:label xml:lang="en">0.08</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >8</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/39">
+        <rdfs:label xml:lang="en">0.39</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >39</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/25">
+        <rdfs:label xml:lang="en">0.25</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >25</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/43">
+        <rdfs:label xml:lang="en">0.43</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >43</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/54">
+        <rdfs:label xml:lang="en">0.54</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >54</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/64">
+        <rdfs:label xml:lang="en">0.64</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >64</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/97">
+        <rdfs:label xml:lang="en">0.97</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >97</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/51">
+        <rdfs:label xml:lang="en">0.51</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >51</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/30">
+        <rdfs:label xml:lang="en">0.30</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >30</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/40">
+        <rdfs:label xml:lang="en">0.40</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >40</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/3">
+        <rdfs:label xml:lang="en">0.03</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >3</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/55">
+        <rdfs:label xml:lang="en">0.55</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >55</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/85">
+        <rdfs:label xml:lang="en">0.85</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >85</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/16">
+        <rdfs:label xml:lang="en">0.16</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >16</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/94">
+        <rdfs:label xml:lang="en">Braking action medium to good</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >94</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/34">
+        <rdfs:label xml:lang="en">0.34</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >34</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/61">
+        <rdfs:label xml:lang="en">0.61</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >61</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/71">
+        <rdfs:label xml:lang="en">0.71</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >71</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/57">
+        <rdfs:label xml:lang="en">0.57</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >57</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/47">
+        <rdfs:label xml:lang="en">0.47</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >47</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <dct:publisher rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/29">
+        <rdfs:label xml:lang="en">0.29</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >29</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/75">
+        <rdfs:label xml:lang="en">0.75</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >75</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/62">
+        <rdfs:label xml:lang="en">0.62</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >62</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/7">
+        <rdfs:label xml:lang="en">0.07</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >7</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/10">
+        <rdfs:label xml:lang="en">0.10</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >10</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/20">
+        <rdfs:label xml:lang="en">0.20</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >20</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/92">
+        <rdfs:label xml:lang="en">Braking action medium to poor</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >92</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-20-089/45">
+        <rdfs:label xml:lang="en">0.45</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >45</skos:notation>
+        <j.0:fxy>020089</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+  </reg:Register>
+</rdf:RDF>

--- a/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-22-061.rdf
+++ b/2.1.1RC1/rule/codes.wmo.int-bufr4-codeflag-0-22-061.rdf
@@ -1,0 +1,145 @@
+<rdf:RDF
+    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:version="http://purl.org/linked-data/version#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:ui="http://purl.org/linked-data/registry-ui#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:qudt-dimension="http://qudt.org/vocab/dimension#"
+    xmlns:ssd="http://www.w3.org/ns/sparql-service-description#"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://codes.wmo.int/def/bufr4/"
+    xmlns:reg="http://purl.org/linked-data/registry#"
+    xmlns:bufr4-core="http://codes.wmo.int/bufr4/schema/core/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:void="http://rdfs.org/ns/void#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:dgu="http://reference.data.gov.uk/def/reference/"
+    xmlns:common-unit="http://codes.wmo.int/common/schema/unit/"
+    xmlns:common-core="http://codes.wmo.int/common/schema/core/"
+    xmlns:qudt="http://qudt.org/schema/qudt#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:qb="http://purl.org/linked-data/cube#"
+    xmlns:grib2-parameter="http://codes.wmo.int/grib2/schema/parameter/"
+    xmlns:qudt-unit="http://qudt.org/vocab/unit#"
+    xmlns:qudt-quantity="http://qudt.org/vocab/quantity#"
+    xmlns:api="http://purl.org/linked-data/api/vocab#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:grib2-core="http://codes.wmo.int/grib2/schema/core/">
+  <ldp:Container rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061">
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/3">
+        <rdfs:label xml:lang="en">Slight</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >3</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">0.5 - 1.25</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <dct:publisher rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+    >2014-09-03T09:55:16.09Z</dct:modified>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/2">
+        <rdfs:label xml:lang="en">Smooth (wavelets)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >2</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">0.1 - 0.5</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <rdf:type rdf:resource="http://purl.org/linked-data/registry#Register"/>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+    >1</owl:versionInfo>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/7">
+        <rdfs:label xml:lang="en">High</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >7</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">6 - 9</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <reg:manager rdf:resource="http://codes.wmo.int/system/organization/www-dm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/15">
+        <rdfs:label xml:lang="en">Missing value</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >15</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/9">
+        <rdfs:label xml:lang="en">Phenomenal</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >9</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">Over 14</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <reg:owner rdf:resource="http://codes.wmo.int/system/organization/wmo"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/6">
+        <rdfs:label xml:lang="en">Very rough</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >6</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">4 - 6</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/1">
+        <rdfs:label xml:lang="en">Calm (rippled)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >1</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">0 - 0.1</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/8">
+        <rdfs:label xml:lang="en">Very high</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >8</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">9 - 14</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <rdfs:label>State of the sea</rdfs:label>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/0">
+        <rdfs:label xml:lang="en">Calm (glassy)</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >0</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">0</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/5">
+        <rdfs:label xml:lang="en">Rough</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >5</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">2.5 - 4</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <ldp:membershipPredicate rdf:resource="http://www.w3.org/2004/02/skos/core#member"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://codes.wmo.int/bufr4/codeflag/0-22-061/4">
+        <rdfs:label xml:lang="en">Moderate</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+        >4</skos:notation>
+        <j.0:fxy>022061</j.0:fxy>
+        <skos:note xml:lang="en">1.25 - 2.5</skos:note>
+      </skos:Concept>
+    </skos:member>
+  </ldp:Container>
+</rdf:RDF>

--- a/2.1.1RC1/rule/iwxxm-collect-codelists.sch
+++ b/2.1.1RC1/rule/iwxxm-collect-codelists.sch
@@ -1,0 +1,735 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+   <sch:title>Schematron validation</sch:title>
+   <sch:ns prefix="collect" uri="http://def.wmo.int/collect/2014"/>
+   <sch:ns prefix="iwxxm" uri="http://icao.int/iwxxm/2.1"/>
+   <sch:ns prefix="sf" uri="http://www.opengis.net/sampling/2.0"/>
+   <sch:ns prefix="sams" uri="http://www.opengis.net/samplingSpatial/2.0"/>
+   <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+   <sch:ns prefix="om" uri="http://www.opengis.net/om/2.0"/>
+   <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+   <sch:ns prefix="aixm" uri="http://www.aixm.aero/schema/5.1.1"/>
+   <sch:pattern id="COLLECT.MB1">
+      <sch:rule context="//collect:MeteorologicalBulletin">
+         <sch:assert test="count(distinct-values(for $item in //collect:meteorologicalInformation/child::node() return(node-name($item))))eq 1">COLLECT.MB1: All meteorologicalInformation instances in MeteorologicalBulletin must be of the same type</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ARS1">
+      <sch:rule context="//iwxxm:AerodromeRunwayState">
+         <sch:assert test="(if(@allRunways eq 'true') then( empty(iwxxm:runway) ) else true())">METAR_SPECI.ARS1: When all runways are being reported upon, no specific Runway should be reported</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ARS2">
+      <sch:rule context="//iwxxm:AerodromeRunwayState">
+         <sch:assert test="(if( exists(iwxxm:runway) ) then( empty(@allRunways) or (@allRunways eq 'false') ) else true())">METAR_SPECI.ARS2: When a single Runway is reported upon, the allRunways flag should be missing or false</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ARVR1">
+      <sch:rule context="//iwxxm:AerodromeRunwayVisualRange">
+         <sch:assert test="(if(exists(iwxxm:meanRVR) and (not(exists(iwxxm:meanRVR/@xsi:nil)) or iwxxm:meanRVR/@xsi:nil != 'true')) then (iwxxm:meanRVR/@uom = 'm') else true())">METAR_SPECI.ARVR1: meanRVR shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep2">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if( empty(iwxxm:observation//iwxxm:cloud/iwxxm:AerodromeObservedClouds) and ends-with(iwxxm:observation//iwxxm:cloud/@nilReason, 'notDetectedByAutoSystem') ) then(@automatedStation eq 'true') else(true()))">METAR_SPECI.MAORep2: When no clouds are detected by the auto system, this report must be an auto report</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep1">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if(@status eq 'MISSING') then( exists(iwxxm:observation//om:result/@nilReason) and ((empty(@automatedStation) or (@automatedStation eq 'false')) and empty(iwxxm:trendForecast)) ) else(true()))">METAR_SPECI.MAORep1: Missing reports only include identifying information (time, aerodrome) and no other information</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep6">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if(exists(.//iwxxm:trendForecast) and not((count(.//iwxxm:trendForecast) eq 1) and (.//iwxxm:trendForecast = ''))) then(empty(distinct-values(for $trend-forecast in .//iwxxm:trendForecast return((deep-equal(.//iwxxm:observation/om:OM_Observation/om:featureOfInterest//sf:sampledFeature,$trend-forecast/om:OM_Observation/om:featureOfInterest//sf:sampledFeature)) or (concat('#', current()//iwxxm:observation/om:OM_Observation/om:featureOfInterest/sams:SF_SpatialSamplingFeature/@gml:id)=$trend-forecast/om:OM_Observation/om:featureOfInterest/@xlink:href)))[.=false()])) else(true()))">METAR_SPECI.MAORep6: The sampled feature should be equal in observation and trendForecast</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep3">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(((exists(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/aixm:AirportHeliport)) or (contains(string(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'aerodrome')) ) and ( if(exists(.//om:OM_Observation/om:featureOfInterest/@xlink:href)) then(concat( '#', current()//om:OM_Observation//sams:SF_SpatialSamplingFeature/@gml:id ) = .//om:OM_Observation/om:featureOfInterest/@xlink:href) else(true())))">METAR_SPECI.MAORep3: The sampled feature for a METAR/SPECI observation is an aerodrome</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep7">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:observation)) then(not(exists(iwxxm:observation//om:procedure/*[name() != 'metce:Process']))) else(true()))">METAR_SPECI.MAORep7: The procedure of a METAR/SPECI observation should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep4">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:observation)) then(not(exists(iwxxm:observation//om:result/*[name() != 'iwxxm:MeteorologicalAerodromeObservationRecord']))) else(true()))">METAR_SPECI.MAORep4: The result of a METAR/SPECI observation should be a MeteorologicalAerodromeObservationRecord</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORep5">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
+         <sch:assert test="(if(exists(iwxxm:trendForecast)) then(not(exists(iwxxm:trendForecast//om:result/*[name() != 'iwxxm:MeteorologicalAerodromeTrendForecastRecord']))) else(true()))">METAR_SPECI.MAORep5: The result of a METAR/SPECI trendForecast should be a MeteorologicalAerodromeTrendForecastRecord</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASS1">
+      <sch:rule context="//iwxxm:AerodromeSeaState">
+         <sch:assert test="(if( exists(iwxxm:seaState) ) then ( empty(iwxxm:significantWaveHeight) ) else (true()))">METAR_SPECI.ASS1: If the sea state is set, significantWaveHeight is not reported (one or the other)</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASS3">
+      <sch:rule context="//iwxxm:AerodromeSeaState">
+         <sch:assert test="(if( empty(iwxxm:seaState) ) then ( exists(iwxxm:significantWaveHeight) ) else (true()))">METAR_SPECI.ASS3: Either seaState or significantWaveHeight must be present</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASS4">
+      <sch:rule context="//iwxxm:AerodromeSeaState">
+         <sch:assert test="(if(exists(iwxxm:seaSurfaceTemperature) and (not(exists(iwxxm:seaSurfaceTemperature/@xsi:nil)) or iwxxm:seaSurfaceTemperature/@xsi:nil != 'true')) then (iwxxm:seaSurfaceTemperature/@uom = 'Cel') else true())">METAR_SPECI.ASS4: seaSurfaceTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASS2">
+      <sch:rule context="//iwxxm:AerodromeSeaState">
+         <sch:assert test="(if( exists(iwxxm:significantWaveHeight) ) then ( empty(iwxxm:seaState) ) else (true()))">METAR_SPECI.ASS2: If the significantWaveHeight is set, seaState is not reported (one or the other)</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASS5">
+      <sch:rule context="//iwxxm:AerodromeSeaState">
+         <sch:assert test="(if(exists(iwxxm:significantWaveHeight) and (not(exists(iwxxm:significantWaveHeight/@xsi:nil)) or iwxxm:significantWaveHeight/@xsi:nil != 'true')) then (iwxxm:significantWaveHeight/@uom = 'm') else true())">METAR_SPECI.ASS5: significantWaveHeight shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AWS1">
+      <sch:rule context="//iwxxm:AerodromeWindShear">
+         <sch:assert test="(if( @allRunways eq 'true' ) then( empty(iwxxm:runway) ) else true())">METAR_SPECI.AWS1: When all runways are affected by wind shear, no specific runways should be reported</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MATFR5">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+         <sch:assert test="(if( @changeIndicator eq 'NO_SIGNIFICANT_CHANGES' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator) and empty(iwxxm:clouds) and empty(iwxxm:forecastWeather) and empty(iwxxm:cloudAndVisibilityOK)) else (true()))">METAR_SPECI.MATFR5: prevailingVisibility, prevailingVisibilityOperator, clouds, forecastWeather and cloudAndVisibilityOK should be absent when changeIndicator equals 'NO_SIGNIFICANT_CHANGES'</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MATFR1">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+         <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MATFR1: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MATFR2">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+         <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:forecastWeather)) else (true()))">METAR_SPECI.MATFR2: forecastWeather should be absent when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MATFR4">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+         <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator)) else (true()))">METAR_SPECI.MATFR4: prevailingVisibility and prevailingVisibilityOperator should be absent when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MATFR3">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+         <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">METAR_SPECI.MATFR3: prevailingVisibility shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec6">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(exists(iwxxm:airTemperature) and (not(exists(iwxxm:airTemperature/@xsi:nil)) or iwxxm:airTemperature/@xsi:nil != 'true')) then (iwxxm:airTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec6: airTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec4">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MAORec4: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec3">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:presentWeather) else true())">METAR_SPECI.MAORec3: presentWeather should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec2">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:rvr) else true())">METAR_SPECI.MAORec2: rvr should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec1">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:visibility) else true())">METAR_SPECI.MAORec1: visibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec7">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(exists(iwxxm:dewpointTemperature) and (not(exists(iwxxm:dewpointTemperature/@xsi:nil)) or iwxxm:dewpointTemperature/@xsi:nil != 'true')) then (iwxxm:dewpointTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec7: dewpointTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec8">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if(exists(iwxxm:qnh) and (not(exists(iwxxm:qnh/@xsi:nil)) or iwxxm:qnh/@xsi:nil != 'true')) then (iwxxm:qnh/@uom = 'hPa') else true())">METAR_SPECI.MAORec8: qnh shall be reported in hectopascals (hPa).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.MAORec5">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+         <sch:assert test="(if((exists(iwxxm:visibility)) and (iwxxm:visibility//iwxxm:prevailingVisibility/number(text()) lt 1500) and (iwxxm:visibility//iwxxm:prevailingVisibility/@uom eq 'm')) then (exists(iwxxm:rvr)) else true())">METAR_SPECI.MAORec5: Table A3-2 Note 7 states: "To be included if visibility or RVR &amp;lt; 1500 m; for up to a maximum of four runways". This is interpreted to mean that if the prevailing visibility is below 1500 meters, RVR should always be included</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AOC1">
+      <sch:rule context="//iwxxm:AerodromeObservedClouds">
+         <sch:assert test="(if( exists(iwxxm:verticalVisibility) ) then empty(iwxxm:layer) else true())">METAR_SPECI.AOC1: Vertical visibility cannot be reported with cloud layers</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AOC2">
+      <sch:rule context="//iwxxm:AerodromeObservedClouds">
+         <sch:assert test="(if(exists(iwxxm:verticalVisibility) and (not(exists(iwxxm:verticalVisibility/@xsi:nil)) or iwxxm:verticalVisibility/@xsi:nil != 'true')) then ((iwxxm:verticalVisibility/@uom = 'm') or (iwxxm:verticalVisibility/@uom = '[ft_i]')) else true())">METAR_SPECI.AOC2: verticalVisibility shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW3">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if(exists(iwxxm:extremeClockwiseWindDirection) and (not(exists(iwxxm:extremeClockwiseWindDirection/@xsi:nil)) or iwxxm:extremeClockwiseWindDirection/@xsi:nil != 'true')) then (iwxxm:extremeClockwiseWindDirection/@uom = 'deg') else true())">METAR_SPECI.ASW3: extremeClockwiseWindDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW4">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if(exists(iwxxm:extremeCounterClockwiseWindDirection) and (not(exists(iwxxm:extremeCounterClockwiseWindDirection/@xsi:nil)) or iwxxm:extremeCounterClockwiseWindDirection/@xsi:nil != 'true')) then (iwxxm:extremeCounterClockwiseWindDirection/@uom = 'deg') else true())">METAR_SPECI.ASW4: extremeCounterClockwiseWindDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW5">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if(exists(iwxxm:meanWindDirection) and (not(exists(iwxxm:meanWindDirection/@xsi:nil)) or iwxxm:meanWindDirection/@xsi:nil != 'true')) then (iwxxm:meanWindDirection/@uom = 'deg') else true())">METAR_SPECI.ASW5: meanWindDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW6">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if(exists(iwxxm:meanWindSpeed) and (not(exists(iwxxm:meanWindSpeed/@xsi:nil)) or iwxxm:meanWindSpeed/@xsi:nil != 'true')) then ((iwxxm:meanWindSpeed/@uom = 'm/s') or (iwxxm:meanWindSpeed/@uom = '[kn_i]')) else true())">METAR_SPECI.ASW6: meanWindSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW2">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if( @variableDirection eq 'true' ) then ( empty(iwxxm:meanWindDirection) ) else true())">METAR_SPECI.ASW2: Wind direction is not reported when variable winds are indicated</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW7">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if(exists(iwxxm:windGustSpeed) and (not(exists(iwxxm:windGustSpeed/@xsi:nil)) or iwxxm:windGustSpeed/@xsi:nil != 'true')) then ((iwxxm:windGustSpeed/@uom = 'm/s') or (iwxxm:windGustSpeed/@uom = '[kn_i]')) else true())">METAR_SPECI.ASW7: windGustSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.ASW1">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWind">
+         <sch:assert test="(if( exists(iwxxm:meanWindDirection)and exists(iwxxm:extremeClockwiseWindDirection)and exists(iwxxm:extremeCounterClockwiseWindDirection) ) then ((iwxxm:meanWindDirection/@uom = iwxxm:extremeClockwiseWindDirection/@uom) and (iwxxm:meanWindDirection/@uom = iwxxm:extremeCounterClockwiseWindDirection/@uom)) else true())">METAR_SPECI.ASW1: All wind UOMs must be the same</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AHV1">
+      <sch:rule context="//iwxxm:AerodromeHorizontalVisibility">
+         <sch:assert test="(if(exists(iwxxm:minimumVisibility) and (not(exists(iwxxm:minimumVisibility/@xsi:nil)) or iwxxm:minimumVisibility/@xsi:nil != 'true')) then (iwxxm:minimumVisibility/@uom = 'm') else true())">METAR_SPECI.AHV1: minimumVisibility shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AHV2">
+      <sch:rule context="//iwxxm:AerodromeHorizontalVisibility">
+         <sch:assert test="(if(exists(iwxxm:minimumVisibilityDirection) and (not(exists(iwxxm:minimumVisibilityDirection/@xsi:nil)) or iwxxm:minimumVisibilityDirection/@xsi:nil != 'true')) then (iwxxm:minimumVisibilityDirection/@uom = 'deg') else true())">METAR_SPECI.AHV2: minimumVisibilityDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="METAR_SPECI.AHV3">
+      <sch:rule context="//iwxxm:AerodromeHorizontalVisibility">
+         <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">METAR_SPECI.AHV3: prevailingVisibility shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.MAFR2">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:cloud) else true())">TAF.MAFR2: cloud should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.MAFR1">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:prevailingVisibility) else true())">TAF.MAFR1: prevailingVisibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.MAFR3">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+         <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:weather) else true())">TAF.MAFR3: weather should not be reported when cloudAndVisibilityOK is true</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.MAFR4">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+         <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">TAF.MAFR4: prevailingVisibility shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.AATF1">
+      <sch:rule context="//iwxxm:AerodromeAirTemperatureForecast">
+         <sch:assert test="(if(exists(iwxxm:maximumTemperature) and (not(exists(iwxxm:maximumTemperature/@xsi:nil)) or iwxxm:maximumTemperature/@xsi:nil != 'true')) then (iwxxm:maximumTemperature/@uom = 'Cel') else true())">TAF.AATF1: maximumTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.AATF2">
+      <sch:rule context="//iwxxm:AerodromeAirTemperatureForecast">
+         <sch:assert test="(if(exists(iwxxm:minimumTemperature) and (not(exists(iwxxm:minimumTemperature/@xsi:nil)) or iwxxm:minimumTemperature/@xsi:nil != 'true')) then (iwxxm:minimumTemperature/@uom = 'Cel') else true())">TAF.AATF2: minimumTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF19">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if(not(empty(iwxxm:baseForecast//om:result/iwxxm:MeteorologicalAerodromeForecastRecord)) and (iwxxm:baseForecast//om:result/iwxxm:MeteorologicalAerodromeForecastRecord/@cloudAndVisibilityOK = 'false')) then(exists(iwxxm:baseForecast//om:result/iwxxm:MeteorologicalAerodromeForecastRecord/iwxxm:cloud)) else(true()))">TAF.TAF19: cloud is mandatory in a non-empty baseForecast when cloudAndVisibilityOK is false</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF18">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if(not(empty(iwxxm:baseForecast//om:result/iwxxm:MeteorologicalAerodromeForecastRecord))) then(not(empty(iwxxm:baseForecast//om:result/iwxxm:MeteorologicalAerodromeForecastRecord/iwxxm:surfaceWind))) else(true()))">TAF.TAF18: surfaceWind is mandatory in a non-empty baseForecast</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF3">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status = 'AMENDMENT' ) then (not(empty(iwxxm:previousReportValidPeriod))) else (true()))">TAF.TAF3: An amended report must also include the valid time of the amended report</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF4">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status = 'CANCELLATION' ) then (not(empty(iwxxm:previousReportValidPeriod))) else (true()))">TAF.TAF4: A cancelled report must also include the valid time of the cancelled report</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF5">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status = 'CORRECTION' ) then (not(empty(iwxxm:previousReportValidPeriod))) else (true()))">TAF.TAF5: A corrected report must reference</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF9">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status = 'MISSING' ) then( (exists(iwxxm:baseForecast//om:result/@nilReason)) and ((empty(iwxxm:validTime)) and ((empty(iwxxm:previousReportValidPeriod)) and (empty(iwxxm:changeForecast))))) else( true()))">TAF.TAF9: Missing TAF reports only include aerodrome information and issue time information</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF2">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status = 'NORMAL' ) then (empty(iwxxm:previousReportValidPeriod)) else (true()))">TAF.TAF2: previousReportValidPeriod must be null unless this cancels, corrects or amends a previous report</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF11">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if( @status ne 'MISSING') then(not(empty(iwxxm:validTime))) else(true()))">TAF.TAF11: Non-missing TAF reports must contains validTime</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF8">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(empty(iwxxm:baseForecast//iwxxm:MeteorologicalAerodromeForecastRecord/@changeIndicator) )">TAF.TAF8: Base conditions may not have a change indicator</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF14">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="( if(exists(.//iwxxm:baseForecast/om:OM_Observation)) then ( ( (exists(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest//sf:sampledFeature/aixm:AirportHeliport)) or (contains(string(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'aerodrome')) ) and ( if(exists(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest/@xlink:href)) then (not(exists(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest[@xlink:href != concat( '#', current()//iwxxm:baseForecast/om:OM_Observation//sams:SF_SpatialSamplingFeature/@gml:id )]))) else(true()) ) ) else(true()) )">TAF.TAF14: The sampled feature of baseForecast is always an aerodrome</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF16">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:baseForecast)) then(not(exists(iwxxm:baseForecast//om:procedure/*[name() != 'metce:Process']))) else(true()))">TAF.TAF16: The procedure of a TAF baseForecast should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF12">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if((exists(.//iwxxm:baseForecast/om:OM_Observation)) and (empty(.//iwxxm:baseForecast/om:OM_Observation/om:result/@nilReason))) then((exists(.//iwxxm:baseForecast/om:OM_Observation/om:validTime/gml:TimePeriod))or(concat( '#', current()//iwxxm:validTime/gml:TimePeriod/@gml:id ) = .//iwxxm:baseForecast/om:OM_Observation/om:validTime/@xlink:href)) else(true()))">TAF.TAF12: The O&amp;amp;M validTime of baseForecast must be a time period for TAF forecasts</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF15">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="( if(exists(.//iwxxm:changeForecast/om:OM_Observation)) then ( ( (exists(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest//sf:sampledFeature/aixm:AirportHeliport)) or (contains(string(.//iwxxm:baseForecast/om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'aerodrome')) ) and ( if(exists(.//iwxxm:changeForecast/om:OM_Observation/om:featureOfInterest/@xlink:href)) then (not(exists(.//iwxxm:changeForecast/om:OM_Observation/om:featureOfInterest[@xlink:href != concat( '#', current()//iwxxm:baseForecast/om:OM_Observation//sams:SF_SpatialSamplingFeature/@gml:id )]))) else(true()) ) ) else(true()) )">TAF.TAF15: The sampled feature of changeForecast is always an aerodrome</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF17">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:changeForecast)) then(not(exists(iwxxm:changeForecast//om:procedure/*[name() != 'metce:Process']))) else(true()))">TAF.TAF17: The procedure of a TAF changeForecast should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF13">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(if((exists(.//iwxxm:changeForecast/om:OM_Observation)) and (empty(.//iwxxm:changeForecast/om:OM_Observation/om:result/@nilReason))) then((exists(.//iwxxm:changeForecast/om:OM_Observation/om:validTime/gml:TimePeriod))or(concat( '#', current()//iwxxm:validTime/gml:TimePeriod/@gml:id ) = .//iwxxm:changeForecast/om:OM_Observation/om:validTime/@xlink:href)) else(true()))">TAF.TAF13: The O&amp;amp;M validTime of changeForecast must be a time period for TAF forecasts</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TAF.TAF6">
+      <sch:rule context="//iwxxm:TAF">
+         <sch:assert test="(empty(distinct-values(for $change-forecast in iwxxm:changeForecast return($change-forecast/om:OM_Observation/om:resultTime//gml:timePosition/text()=iwxxm:baseForecast/om:OM_Observation/om:resultTime//gml:timePosition/text())or($change-forecast/om:OM_Observation/om:resultTime/@xlink:href=iwxxm:baseForecast/om:OM_Observation/om:resultTime/@xlink:href))[.=false()]))">TAF.TAF6: resultTime for the baseForecast and the changeForecasts must match</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET9">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(exists(iwxxm:forecastPositionAnalysis)) then(not(exists(iwxxm:analysis/om:OM_Observation/om:result/iwxxm:EvolvingMeteorologicalCondition/iwxxm:speedOfMotion)) and not(exists(iwxxm:analysis/om:OM_Observation/om:result/iwxxm:EvolvingMeteorologicalCondition/iwxxm:directionOfMotion))) else(true()))">SIGMET.SIGMET9: SIGMET can not have both a forecastPositionAnalysis and expected speed and/or direction of motion</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET1">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(@status = 'CANCELLATION') then exists(iwxxm:analysis//om:result/@nilReason) else(true()))">SIGMET.SIGMET1: A cancelled SIGMET should only include identifying information (time and airspace) and no other information</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET2">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(@status = 'NORMAL') then ((exists(iwxxm:analysis)) and (empty(iwxxm:analysis//om:result/@nilReason))) else(true()))">SIGMET.SIGMET2: There must be at least one analysis when a SIGMET does not have canceled status</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET10">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(exists(iwxxm:volcanicAshMovedToFIR)) then(@status = 'CANCELLATION') else(true()))">SIGMET.SIGMET10: SIGMET must have a cancelled status if reporting volcanicAshMovedToFIR</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET4">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="( if((@status ne 'CANCELLATION') and (not(@translationFailedTAC))) then((exists(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/aixm:Airspace)) or (contains(string(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'fir')) or (contains(string(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'uir')) or (contains(string(.//om:OM_Observation/om:featureOfInterest//sf:sampledFeature/@xlink:href), 'cta')) ) and ( if(exists(.//om:OM_Observation/om:featureOfInterest/@xlink:href)) then (concat( '#', current()//om:OM_Observation//sams:SF_SpatialSamplingFeature/@gml:id ) = .//om:OM_Observation/om:featureOfInterest/@xlink:href) else(true())) else(true()))">SIGMET.SIGMET4: Sampled feature in analysis and forecastPositionAnalysis must be an FIR, UIR, or CTA</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET7">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:analysis)) then(not(exists(iwxxm:analysis//om:procedure/*[name() != 'metce:Process']))) else(true()))">SIGMET.SIGMET7: The procedure of a SIGMET analysis should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET3">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if((@status ne 'CANCELLATION') and exists(//iwxxm:analysis/om:OM_Observation)) then(exists(//iwxxm:analysis/om:OM_Observation/om:result/iwxxm:SIGMETEvolvingConditionCollection)) else(true()))">SIGMET.SIGMET3: OBS and FCST analyses must have a result type of SIGMETEvolvingConditionCollection</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET8">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:forecastPositionAnalysis)) then(not(exists(iwxxm:forecastPositionAnalysis//om:procedure/*[name() != 'metce:Process']))) else(true()))">SIGMET.SIGMET8: The procedure of a SIGMET forecastPositionAnalysis should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SIGMET5">
+      <sch:rule context="//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET">
+         <sch:assert test="(if((@status ne 'CANCELLATION') and exists(iwxxm:forecastPositionAnalysis)) then(not(exists(iwxxm:forecastPositionAnalysis//om:result/*[name() != 'iwxxm:SIGMETPositionCollection']))) else(true()))">SIGMET.SIGMET5: The result of a forecastPositionAnalysis should be a SIGMETPositionCollection</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SEC1">
+      <sch:rule context="//iwxxm:SIGMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:directionOfMotion) and (not(exists(iwxxm:directionOfMotion/@xsi:nil)) or iwxxm:directionOfMotion/@xsi:nil != 'true')) then (iwxxm:directionOfMotion/@uom = 'deg') else true())">SIGMET.SEC1: directionOfMotion shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SEC2">
+      <sch:rule context="//iwxxm:SIGMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:speedOfMotion) and (not(exists(iwxxm:speedOfMotion/@xsi:nil)) or iwxxm:speedOfMotion/@xsi:nil != 'true')) then ((iwxxm:speedOfMotion/@uom = 'km/h') or (iwxxm:speedOfMotion/@uom = '[kn_i]')) else true())">SIGMET.SEC2: speedOfMotion shall be reported in kilometres per hour (km/h) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SECC3">
+      <sch:rule context="//iwxxm:SIGMETEvolvingConditionCollection">
+         <sch:assert test="(if(exists(/iwxxm:SIGMET)) then(count(iwxxm:member) eq 1) else(true()))">SIGMET.SECC3: The number of SIGMETEvolvingConditionCollection member should be 1 for non-Tropical Cyclone/Volcanic Ash SIGMETs</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SECC2">
+      <sch:rule context="//iwxxm:SIGMETEvolvingConditionCollection">
+         <sch:assert test="(if(@timeIndicator='FORECAST' and ../../om:phenomenonTime/gml:TimeInstant/gml:timePosition) then (translate(../../om:phenomenonTime/gml:TimeInstant/gml:timePosition,'-T:Z','') ge translate(../../../../iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition,'-T:Z','')) else(true()))">SIGMET.SECC2: When SIGMETEvolvingConditionCollection timeIndicator is a forecast, the phenomenonTime must be later than or equal to the beginning of the validPeriod of the report.</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SECC1">
+      <sch:rule context="//iwxxm:SIGMETEvolvingConditionCollection">
+         <sch:assert test="(if(@timeIndicator='OBSERVATION' and ../../om:phenomenonTime/gml:TimeInstant/gml:timePosition) then (translate(../../om:phenomenonTime/gml:TimeInstant/gml:timePosition,'-T:Z','') le translate(../../../../iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition,'-T:Z','')) else(true()))">SIGMET.SECC1: When SIGMETEvolvingConditionCollection timeIndicator is an observation, the phenomenonTime must be earlier than or equal to the beginning of the validPeriod of the report.</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="SIGMET.SPC1">
+      <sch:rule context="//iwxxm:SIGMETPositionCollection">
+         <sch:assert test="(if(exists(/iwxxm:SIGMET)) then(count(iwxxm:member) eq 1) else(true()))">SIGMET.SPC1: The number of SIGMETPositionCollection member should be 1 for non-Tropical Cyclone/Volcanic Ash SIGMETs</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AECC2">
+      <sch:rule context="//iwxxm:AIRMETEvolvingConditionCollection">
+         <sch:assert test="(if(@timeIndicator='FORECAST' and ../../om:phenomenonTime/gml:TimeInstant/gml:timePosition) then (translate(../../om:phenomenonTime/gml:TimeInstant/gml:timePosition,'-T:Z','') ge translate(../../../../iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition,'-T:Z','')) else true())">AIRMET.AECC2: When AIRMETEvolvingConditionCollection timeIndicator is a forecast, the phenomenonTime must be later than or equal to the beginning of the validPeriod of the report.</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AECC1">
+      <sch:rule context="//iwxxm:AIRMETEvolvingConditionCollection">
+         <sch:assert test="(if(@timeIndicator='OBSERVATION' and ../../om:phenomenonTime/gml:TimeInstant/gml:timePosition) then (translate(../../om:phenomenonTime/gml:TimeInstant/gml:timePosition,'-T:Z','') le translate(../../../../iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition,'-T:Z','')) else true())">AIRMET.AECC1: When AIRMETEvolvingConditionCollection timeIndicator is an observation, the phenomenonTime must be earlier than or equal to the beginning of the validPeriod of the report.</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC1">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:cloudBase) and (not(exists(iwxxm:cloudBase/@xsi:nil)) or iwxxm:cloudBase/@xsi:nil != 'true')) then ((iwxxm:cloudBase/@uom = 'm') or (iwxxm:cloudBase/@uom = '[ft_i]')) else true())">AIRMET.AEC1: cloudBase shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC2">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:cloudTop) and (not(exists(iwxxm:cloudTop/@xsi:nil)) or iwxxm:cloudTop/@xsi:nil != 'true')) then ((iwxxm:cloudTop/@uom = 'm') or (iwxxm:cloudTop/@uom = '[ft_i]')) else true())">AIRMET.AEC2: cloudTop shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC3">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:directionOfMotion) and (not(exists(iwxxm:directionOfMotion/@xsi:nil)) or iwxxm:directionOfMotion/@xsi:nil != 'true')) then (iwxxm:directionOfMotion/@uom = 'deg') else true())">AIRMET.AEC3: directionOfMotion shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC4">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:speedOfMotion) and (not(exists(iwxxm:speedOfMotion/@xsi:nil)) or iwxxm:speedOfMotion/@xsi:nil != 'true')) then ((iwxxm:speedOfMotion/@uom = 'km/h') or (iwxxm:speedOfMotion/@uom = '[kn_i]')) else true())">AIRMET.AEC4: speedOfMotion shall be reported in kilometres per hour (km/h) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC5">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:surfaceVisibility) and (not(exists(iwxxm:surfaceVisibility/@xsi:nil)) or iwxxm:surfaceVisibility/@xsi:nil != 'true')) then (iwxxm:surfaceVisibility/@uom = 'm') else true())">AIRMET.AEC5: surfaceVisibility shall be reported in metres (m).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC7">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:surfaceWindDirection) and (not(exists(iwxxm:surfaceWindDirection/@xsi:nil)) or iwxxm:surfaceWindDirection/@xsi:nil != 'true')) then ((iwxxm:surfaceWindDirection/@uom = 'deg')) else true())">AIRMET.AEC7: surfaceWindDirection shall be reported in the degrees unit of measure ('deg').</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC6">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:surfaceWindSpeed) and (not(exists(iwxxm:surfaceWindSpeed/@xsi:nil)) or iwxxm:surfaceWindSpeed/@xsi:nil != 'true')) then ((iwxxm:surfaceWindSpeed/@uom = 'm/s') or (iwxxm:surfaceWindSpeed/@uom = '[kn_i]')) else true())">AIRMET.AEC6: surfaceWindSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AEC8">
+      <sch:rule context="//iwxxm:AIRMETEvolvingCondition">
+         <sch:assert test="(if(exists(iwxxm:surfaceWindDirection) or exists(iwxxm:surfaceWindSpeed)) then (exists(iwxxm:surfaceWindDirection) and exists(iwxxm:surfaceWindSpeed)) else true())">AIRMET.AEC8: surfaceWindDirection and surfaceWindSpeed must be reported together</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AIRMET5">
+      <sch:rule context="//iwxxm:AIRMET">
+         <sch:assert test="(if(exists(iwxxm:forecastPositionAnalysis)) then(not(exists(iwxxm:analysis/om:OM_Observation/om:result/iwxxm:AIRMETEvolvingMeteorologicalCondition/iwxxm:speedOfMotion)) and not(exists(iwxxm:analysis/om:OM_Observation/om:result/iwxxm:AIRMETEvolvingMeteorologicalCondition/iwxxm:directionOfMotion))) else(true()))">AIRMET.AIRMET5: AIRMET can not have both a forecastPositionAnalysis and expected speed and/or direction of motion</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AIRMET2">
+      <sch:rule context="//iwxxm:AIRMET">
+         <sch:assert test="(if(@status = 'CANCELLATION') then exists(iwxxm:analysis//om:result/@nilReason) else(true()))">AIRMET.AIRMET2: A canceled AIRMET only include identifying information (time and airspace) and no other information</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AIRMET3">
+      <sch:rule context="//iwxxm:AIRMET">
+         <sch:assert test="(if(@status = 'NORMAL') then ((exists(iwxxm:analysis)) and (empty(iwxxm:analysis//om:result/@nilReason))) else(true()))">AIRMET.AIRMET3: There must be at least one analysis when a AIRMET does not have canceled status</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AIRMET4">
+      <sch:rule context="//iwxxm:AIRMET">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:analysis)) then(not(exists(iwxxm:analysis//om:procedure/*[name() != 'metce:Process']))) else(true()))">AIRMET.AIRMET4: The procedure of an AIRMET analysis should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="AIRMET.AIRMET1">
+      <sch:rule context="//iwxxm:AIRMET">
+         <sch:assert test="(if((@status ne 'CANCELLATION') and exists(//iwxxm:analysis/om:OM_Observation)) then(exists(//iwxxm:analysis/om:OM_Observation/om:result/iwxxm:AIRMETEvolvingConditionCollection)) else(true()))">AIRMET.AIRMET1: OBS and FCST classifications must have a result type of AIRMETEvolvingConditionCollection</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCFC1">
+      <sch:rule context="//iwxxm:TropicalCycloneForecastConditions">
+         <sch:assert test="(if(exists(iwxxm:maximumSurfaceWindSpeed) and (not(exists(iwxxm:maximumSurfaceWindSpeed/@xsi:nil)) or iwxxm:maximumSurfaceWindSpeed/@xsi:nil != 'true')) then ((iwxxm:maximumSurfaceWindSpeed/@uom = 'm/s') or (iwxxm:maximumSurfaceWindSpeed/@uom = '[kn_i]')) else true())">TCA.TCFC1: maximumSurfaceWindSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCA4">
+      <sch:rule context="//iwxxm:TropicalCycloneAdvisory">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:forecast)) then(not(exists(iwxxm:forecast//om:procedure/*[name() != 'metce:Process']))) else(true()))">TCA.TCA4: The procedure of a TCA forecast should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCA2">
+      <sch:rule context="//iwxxm:TropicalCycloneAdvisory">
+         <sch:assert test="(if(exists(iwxxm:forecast)) then(not(exists(iwxxm:forecast//om:result/*[name() != 'iwxxm:TropicalCycloneForecastConditions']))) else(true()))">TCA.TCA2: The result of a TCA forecast should be a TropicalCycloneForecastConditions</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCA3">
+      <sch:rule context="//iwxxm:TropicalCycloneAdvisory">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:observation)) then(not(exists(iwxxm:observation//om:procedure/*[name() != 'metce:Process']))) else(true()))">TCA.TCA3: The procedure of a TCA observation should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCA1">
+      <sch:rule context="//iwxxm:TropicalCycloneAdvisory">
+         <sch:assert test="(if(exists(iwxxm:observation)) then(not(exists(iwxxm:observation//om:result/*[name() != 'iwxxm:TropicalCycloneObservedConditions']))) else(true()))">TCA.TCA1: The result of a TCA observation should be a TropicalCycloneObservedConditions</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCOC1">
+      <sch:rule context="//iwxxm:TropicalCycloneObservedConditions">
+         <sch:assert test="(if(exists(iwxxm:centralPressure) and (not(exists(iwxxm:centralPressure/@xsi:nil)) or iwxxm:centralPressure/@xsi:nil != 'true')) then (iwxxm:centralPressure/@uom = 'hPa') else true())">TCA.TCOC1: centralPressure shall be reported in hectopascals (hPa).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCOC2">
+      <sch:rule context="//iwxxm:TropicalCycloneObservedConditions">
+         <sch:assert test="(if(exists(iwxxm:meanMaxSurfaceWind) and (not(exists(iwxxm:meanMaxSurfaceWind/@xsi:nil)) or iwxxm:meanMaxSurfaceWind/@xsi:nil != 'true')) then ((iwxxm:meanMaxSurfaceWind/@uom = 'm/s') or (iwxxm:meanMaxSurfaceWind/@uom = '[kn_i]')) else true())">TCA.TCOC2: meanMaxSurfaceWind shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCOC3">
+      <sch:rule context="//iwxxm:TropicalCycloneObservedConditions">
+         <sch:assert test="(if(exists(iwxxm:movementDirection) and (not(exists(iwxxm:movementDirection/@xsi:nil)) or iwxxm:movementDirection/@xsi:nil != 'true')) then (iwxxm:movementDirection/@uom = 'deg') else true())">TCA.TCOC3: movementDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="TCA.TCOC4">
+      <sch:rule context="//iwxxm:TropicalCycloneObservedConditions">
+         <sch:assert test="(if(exists(iwxxm:movementSpeed) and (not(exists(iwxxm:movementSpeed/@xsi:nil)) or iwxxm:movementSpeed/@xsi:nil != 'true')) then ((iwxxm:movementSpeed/@uom = 'km/h') or (iwxxm:movementSpeed/@uom = '[kn_i]')) else true())">TCA.TCOC4: movementSpeed shall be reported in kilometres per hour (km/h) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAC1">
+      <sch:rule context="//iwxxm:VolcanicAshCloud">
+         <sch:assert test="(if(exists(iwxxm:directionOfMotion) and (not(exists(iwxxm:directionOfMotion/@xsi:nil)) or iwxxm:directionOfMotion/@xsi:nil != 'true')) then (iwxxm:directionOfMotion/@uom = 'deg') else true())">VAA.VAC1: directionOfMotion shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAC2">
+      <sch:rule context="//iwxxm:VolcanicAshCloud">
+         <sch:assert test="(if(exists(iwxxm:speedOfMotion) and (not(exists(iwxxm:speedOfMotion/@xsi:nil)) or iwxxm:speedOfMotion/@xsi:nil != 'true')) then ((iwxxm:speedOfMotion/@uom = 'km/h') or (iwxxm:speedOfMotion/@uom = '[kn_i]')) else true())">VAA.VAC2: speedOfMotion shall be reported in kilometres per hour (km/h) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAC3">
+      <sch:rule context="//iwxxm:VolcanicAshCloud">
+         <sch:assert test="(if(exists(iwxxm:windDirection) and (not(exists(iwxxm:windDirection/@xsi:nil)) or iwxxm:windDirection/@xsi:nil != 'true')) then (iwxxm:windDirection/@uom = 'deg') else true())">VAA.VAC3: windDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAC4">
+      <sch:rule context="//iwxxm:VolcanicAshCloud">
+         <sch:assert test="(if(exists(iwxxm:windSpeed) and (not(exists(iwxxm:windSpeed/@xsi:nil)) or iwxxm:windSpeed/@xsi:nil != 'true')) then ((iwxxm:windSpeed/@uom = 'm/s') or (iwxxm:windSpeed/@uom = '[kn_i]')) else true())">VAA.VAC4: windSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAA2">
+      <sch:rule context="//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="(if(empty(om:result/@nilReason) and exists(iwxxm:analysis)) then(not(exists(iwxxm:analysis//om:procedure/*[name() != 'metce:Process']))) else(true()))">VAA.VAA2: The procedure of a VAA analysis should be a metce:Process</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="VAA.VAA1">
+      <sch:rule context="//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="(if(exists(iwxxm:analysis)) then(not(exists(iwxxm:analysis//om:result/*[name() != 'iwxxm:VolcanicAshConditions']))) else(true()))">VAA.VAA1: The result of a VAA analysis should be a VolcanicAshConditions</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.CL1">
+      <sch:rule context="//iwxxm:CloudLayer">
+         <sch:assert test="(if(exists(iwxxm:base) and (not(exists(iwxxm:base/@xsi:nil)) or iwxxm:base/@xsi:nil != 'true')) then ((iwxxm:base/@uom = 'm') or (iwxxm:base/@uom = '[ft_i]')) else true())">COMMON.CL1: base shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.Report4">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.Report2">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="(if(@permissibleUsage eq 'OPERATIONAL') then( not( exists(@permissibleUsageReason))) else(true()))">COMMON.Report2: Operational reports should not include a permissibleUsageReason</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.Report1">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="(if(@permissibleUsage eq 'NON-OPERATIONAL') then( exists(@permissibleUsageReason) ) else(true()))">COMMON.Report1: Non-operational reports must include a permissibleUsageReason</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.Report3">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="(if( exists(@translatedBulletinID) or exists(@translatedBulletinReceptionTime) or exists(@translationCentreDesignator) or exists(@translationCentreName) or exists(@translationTime) or exists(@translationFailedTAC)) then( exists(@translatedBulletinID) and exists(@translatedBulletinReceptionTime) and exists(@translationCentreDesignator) and exists(@translationCentreName) and exists(@translationTime)) else(true()))">COMMON.Report3: Translated reports must include translatedBulletinID, translatedBulletinReceptionTime, translationCentreDesignator, translationCentreName, translationTime and optionally translationFailedTAC if translation failed</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ACF1">
+      <sch:rule context="//iwxxm:AerodromeCloudForecast">
+         <sch:assert test="(if( exists(iwxxm:verticalVisibility) ) then empty(iwxxm:layer) else true())">COMMON.ACF1: Vertical visibility cannot be reported together with cloud layers</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ACF2">
+      <sch:rule context="//iwxxm:AerodromeCloudForecast">
+         <sch:assert test="(if(exists(iwxxm:verticalVisibility) and (not(exists(iwxxm:verticalVisibility/@xsi:nil)) or iwxxm:verticalVisibility/xsi:nil != 'true')) then ((iwxxm:verticalVisibility/@uom = 'm') or (iwxxm:verticalVisibility/@uom = '[ft_i]')) else true())">COMMON.ACF2: verticalVisibility shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ASWF1">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWindForecast">
+         <sch:assert test="(if( @variableDirection eq 'true' ) then ( empty(iwxxm:meanWindDirection) ) else true())">COMMON.ASWF1: Wind direction is not reported when variable winds are indicated</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ASWTF1">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWindTrendForecast|//iwxxm:AerodromeSurfaceWindForecast">
+         <sch:assert test="(if(exists(iwxxm:meanWindDirection) and (not(exists(iwxxm:meanWindDirection/@xsi:nil)) or iwxxm:meanWindDirection/@xsi:nil != 'true')) then (iwxxm:meanWindDirection/@uom = 'deg') else true())">COMMON.ASWTF1: meanWindDirection shall be reported in degrees (deg).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ASWTF2">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWindTrendForecast|//iwxxm:AerodromeSurfaceWindForecast">
+         <sch:assert test="(if(exists(iwxxm:meanWindSpeed) and (not(exists(iwxxm:meanWindSpeed/@xsi:nil)) or iwxxm:meanWindSpeed/@xsi:nil != 'true')) then ((iwxxm:meanWindSpeed/@uom = 'm/s') or (iwxxm:meanWindSpeed/@uom = '[kn_i]')) else true())">COMMON.ASWTF2: meanWindSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="COMMON.ASWTF3">
+      <sch:rule context="//iwxxm:AerodromeSurfaceWindTrendForecast|//iwxxm:AerodromeSurfaceWindForecast">
+         <sch:assert test="(if(exists(iwxxm:windGustSpeed) and (not(exists(iwxxm:windGustSpeed/@xsi:nil)) or iwxxm:windGustSpeed/@xsi:nil != 'true')) then ((iwxxm:windGustSpeed/@uom = 'm/s') or (iwxxm:windGustSpeed/@uom = '[kn_i]')) else true())">COMMON.ASWTF3: windGustSpeed shall be reported in metres per second (m/s) or knots ([kn_i]).</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+   <sch:pattern id="IWXXM.ExtensionAlwaysLast">
+      <sch:rule context="//iwxxm:extension">
+         <sch:assert test="following-sibling::*[1][self::iwxxm:extension] or not(following-sibling::*)">IWXXM.ExtensionAlwaysLast: Extension elements should be the last elements in their parents</sch:assert>
+      </sch:rule>
+   </sch:pattern>
+  <!-- Rules to enforce WMO Code List constraints are below this line -->
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="reg" uri="http://purl.org/linked-data/registry#"/>
+
+  <sch:let name="dSigWxPhenomena" value="document('codes.wmo.int-49-2-SigWxPhenomena.rdf')" />
+  <sch:let name="dWeatherCausingVisibilityReduction" value="document('codes.wmo.int-49-2-WeatherCausingVisibilityReduction.rdf')" />
+  <sch:let name="dAerodromePresentOrForecastWeather" value="document('codes.wmo.int-49-2-AerodromePresentOrForecastWeather.rdf')" />
+  <sch:let name="d020089" value="document('codes.wmo.int-bufr4-codeflag-0-20-089.rdf')" />
+  <sch:let name="dAerodromeRecentWeather" value="document('codes.wmo.int-49-2-AerodromeRecentWeather.rdf')" />
+  <sch:let name="dCloudAmountReportedAtAerodrome" value="document('codes.wmo.int-49-2-CloudAmountReportedAtAerodrome.rdf')" />
+  <sch:let name="d020086" value="document('codes.wmo.int-bufr4-codeflag-0-20-086.rdf')" />
+  <sch:let name="dAviationColourCode" value="document('codes.wmo.int-49-2-AviationColourCode.rdf')" />
+  <sch:let name="dSigConvectiveCloudType" value="document('codes.wmo.int-49-2-SigConvectiveCloudType.rdf')" />
+  <sch:let name="d020087" value="document('codes.wmo.int-bufr4-codeflag-0-20-087.rdf')" />
+  <sch:let name="dAirWxPhenomena" value="document('codes.wmo.int-49-2-AirWxPhenomena.rdf')" />
+  <sch:let name="d022061" value="document('codes.wmo.int-bufr4-codeflag-0-22-061.rdf')" />
+
+  <sch:pattern id="phenomenon-dSigWxPhenomena-test">
+    <sch:rule context="//*[contains(name(),'SIGMET')]/iwxxm:phenomenon">
+      <sch:assert test="@xlink:href = $dSigWxPhenomena/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        SIGMET iwxxm:phenomenon elements should be a member of http://codes.wmo.int/49-2/SigWxPhenomena
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="surfaceVisibilityCause-dWeatherCausingVisibilityReduction-test">
+    <sch:rule context="//*[contains(name(),'AIRMETEvolvingCondition')]/iwxxm:surfaceVisibilityCause">
+      <sch:assert test="@xlink:href = $dWeatherCausingVisibilityReduction/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AIRMETEvolvingCondition iwxxm:surfaceVisibilityCause elements should be a member of http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="forecastWeather-dAerodromePresentOrForecastWeather-test">
+    <sch:rule context="//*[contains(name(),'MeteorologicalAerodromeTrendForecastRecord')]/iwxxm:forecastWeather">
+      <sch:assert test="@xlink:href = $dAerodromePresentOrForecastWeather/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        MeteorologicalAerodromeTrendForecastRecord iwxxm:forecastWeather elements should be a member of http://codes.wmo.int/49-2/AerodromePresentOrForecastWeather
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="weather-dAerodromePresentOrForecastWeather-test">
+    <sch:rule context="//*[contains(name(),'MeteorologicalAerodromeForecastRecord')]/iwxxm:weather">
+      <sch:assert test="@xlink:href = $dAerodromePresentOrForecastWeather/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        MeteorologicalAerodromeForecastRecord iwxxm:weather elements should be a member of http://codes.wmo.int/49-2/AerodromePresentOrForecastWeather
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="estimatedSurfaceFrictionOrBrakingAction-d020089-test">
+    <sch:rule context="//*[contains(name(),'AerodromeRunwayState')]/iwxxm:estimatedSurfaceFrictionOrBrakingAction">
+      <sch:assert test="@xlink:href = $d020089/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AerodromeRunwayState iwxxm:estimatedSurfaceFrictionOrBrakingAction elements should be a member of http://codes.wmo.int/bufr4/codeflag/0-20-089
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="recentWeather-dAerodromeRecentWeather-test">
+    <sch:rule context="//*[contains(name(),'MeteorologicalAerodromeObservationRecord')]/iwxxm:recentWeather">
+      <sch:assert test="@xlink:href = $dAerodromeRecentWeather/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        MeteorologicalAerodromeObservationRecord iwxxm:recentWeather elements should be a member of http://codes.wmo.int/49-2/AerodromeRecentWeather
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="amount-dCloudAmountReportedAtAerodrome-test">
+    <sch:rule context="//*[contains(name(),'CloudLayer')]/iwxxm:amount">
+      <sch:assert test="@xlink:href = $dCloudAmountReportedAtAerodrome/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        CloudLayer iwxxm:amount elements should be a member of http://codes.wmo.int/49-2/CloudAmountReportedAtAerodrome
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="depositType-d020086-test">
+    <sch:rule context="//*[contains(name(),'AerodromeRunwayState')]/iwxxm:depositType">
+      <sch:assert test="@xlink:href = $d020086/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AerodromeRunwayState iwxxm:depositType elements should be a member of http://codes.wmo.int/bufr4/codeflag/0-20-086
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="colourCode-dAviationColourCode-test">
+    <sch:rule context="//*[contains(name(),'VolcanicAshAdvisory')]/iwxxm:colourCode">
+      <sch:assert test="@xlink:href = $dAviationColourCode/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        VolcanicAshAdvisory iwxxm:colourCode elements should be a member of http://codes.wmo.int/49-2/AviationColourCode
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="cloudType-dSigConvectiveCloudType-test">
+    <sch:rule context="//*[contains(name(),'CloudLayer')]/iwxxm:cloudType">
+      <sch:assert test="@xlink:href = $dSigConvectiveCloudType/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        CloudLayer iwxxm:cloudType elements should be a member of http://codes.wmo.int/49-2/SigConvectiveCloudType
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="contamination-d020087-test">
+    <sch:rule context="//*[contains(name(),'AerodromeRunwayState')]/iwxxm:contamination">
+      <sch:assert test="@xlink:href = $d020087/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AerodromeRunwayState iwxxm:contamination elements should be a member of http://codes.wmo.int/bufr4/codeflag/0-20-087
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="presentWeather-dAerodromePresentOrForecastWeather-test">
+    <sch:rule context="//*[contains(name(),'MeteorologicalAerodromeObservationRecord')]/iwxxm:presentWeather">
+      <sch:assert test="@xlink:href = $dAerodromePresentOrForecastWeather/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        MeteorologicalAerodromeObservationRecord iwxxm:presentWeather elements should be a member of http://codes.wmo.int/49-2/AerodromePresentOrForecastWeather
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="phenomenon-dAirWxPhenomena-test">
+    <sch:rule context="//*[contains(name(),'AIRMET')]/iwxxm:phenomenon">
+      <sch:assert test="@xlink:href = $dAirWxPhenomena/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AIRMET iwxxm:phenomenon elements should be a member of http://codes.wmo.int/49-2/AirWxPhenomena
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="seaState-d022061-test">
+    <sch:rule context="//*[contains(name(),'AerodromeSeaState')]/iwxxm:seaState">
+      <sch:assert test="@xlink:href = $d022061/rdf:RDF/*/skos:member/*/@*[local-name()='about'] or @nilReason" >
+        AerodromeSeaState iwxxm:seaState elements should be a member of http://codes.wmo.int/bufr4/codeflag/0-22-061
+      </sch:assert>
+    </sch:rule>
+  </sch:pattern>
+
+</sch:schema>


### PR DESCRIPTION
This is an optional, preview version of Schematron rules that ensure that WMO Codes List references are correct for each IWXXM element, and in a later IWXXM release will be merged into iwxxm.sch.  RDF versions of each codelist entry (downloaded less than an hour ago) are included for local, offline validation