### PR TITLE
Updated examples and SCH files to UUIDv4

### DIFF
--- a/3.0.0RC1/examples/airmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/airmet-A6-1a-TS.xml
@@ -15,12 +15,12 @@
     http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     
     permissibleUsage="OPERATIONAL"
-    gml:id="airmet-YUDD-201405151520Z" status="NORMAL">
+    gml:id="uuid.69a2497b-193c-47bf-a6bd-1cc71acbc8e5" status="NORMAL">
     
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-YUDD">
+        <aixm:Unit gml:id="uuid.1b54b36f-bc16-4111-abb6-05ff6aad744b">
           <aixm:timeSlice>
-              <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+              <aixm:UnitTimeSlice gml:id="uuid.91cf4ebe-8687-432f-a1e1-aaf7ebc053b2">
               <gml:validTime/>
               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
               <aixm:name>YUDD FIC</aixm:name>
@@ -31,9 +31,9 @@
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-      <aixm:Unit gml:id="wmo-YUDD">
+      <aixm:Unit gml:id="uuid.30437923-6a83-4bc7-a07e-66e7419e50df">
           <aixm:timeSlice>
-            <aixm:UnitTimeSlice gml:id="wmo-YUDD-ts">
+            <aixm:UnitTimeSlice gml:id="uuid.f8eb9604-6ddb-4553-9d9e-84548fb7af42">
               <gml:validTime/>
               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
               <aixm:name>YUDD MWO</aixm:name>
@@ -47,7 +47,7 @@
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
     
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp1">
+        <gml:TimePeriod gml:id="uuid.74b125c2-a4ad-4434-b3c0-f650eb57ce93">
             <gml:beginPosition>2014-05-15T15:20:00</gml:beginPosition>
             <gml:endPosition>2014-05-15T18:00:00</gml:endPosition>
         </gml:TimePeriod>
@@ -57,33 +57,33 @@
     
     <!-- OBS N OF S50 TOP ABV FL100 STNR WKN -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="analysis">
+        <om:OM_Observation gml:id="uuid.31e77f13-c64e-4904-ad50-5886d9c99747">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/AIRMETEvolvingConditionCollectionAnalysis"/>
             <!-- time of observed conditions -->
             <om:phenomenonTime nilReason="missing"/>
             
             <!-- time at which the results of the observation were made available -->
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-20140515T1520Z">
+                <gml:TimeInstant gml:id="uuid.6ffb87f7-6eef-4bae-b4f2-016e2951d7dd">
                     <gml:timePosition>2014-05-15T15:20:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <!-- The valid period for this observation is the period of the entire AIRMET -->
             <om:validTime xlink:href="#tp1"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-airmet">
+                <metce:Process gml:id="uuid.be73c6d1-a164-45ec-951e-e8b665397c0b">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO AIRMET INFORMATION</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/AIRMETEvolvingConditionCollectionAnalysis"/>
             <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-surface-Amswell">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.4be2f92a-f3f9-42a3-9237-f034170647a4">
                     <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
                     <sam:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.15c2c2ba-c5f2-47b5-9ada-1964d51b82c0">
+                        <aixm:Airspace gml:id="uuid.09f5436c-cf2c-40ca-add5-c95a8f6875f9">
                           <aixm:timeSlice>
-                            <aixm:AirspaceTimeSlice gml:id="ats3">
+                            <aixm:AirspaceTimeSlice gml:id="uuid.c62fe63e-792d-49e6-9f09-b6c2940d1591">
                               <gml:validTime/>
                               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                               <aixm:type>FIR</aixm:type>
@@ -99,16 +99,16 @@
             </om:featureOfInterest>
             <om:result>
                 <!-- N OF S50 TOP ABV FL100 STNR WKN -->
-                <iwxxm:AIRMETEvolvingConditionCollection gml:id="cb-aecc1" timeIndicator="OBSERVATION">
+                <iwxxm:AIRMETEvolvingConditionCollection gml:id="uuid.d61fb5e7-b55e-462e-9e2b-0cb8dc366064" timeIndicator="OBSERVATION">
                   <iwxxm:member>
-                    <iwxxm:AIRMETEvolvingCondition gml:id="cb-aec1" intensityChange="WEAKEN">
+                    <iwxxm:AIRMETEvolvingCondition gml:id="uuid.deeb1ae5-0094-4ec8-af92-aa7b3f156a3f" intensityChange="WEAKEN">
                       <iwxxm:directionOfMotion xsi:nil="true" uom="N/A" nilReason="inapplicable"/>
                       <iwxxm:geometry>
-                        <aixm:AirspaceVolume gml:id="as1">
+                        <aixm:AirspaceVolume gml:id="uuid.8ed71782-7c63-4ca5-9ed6-a31b788f64af">
                           <aixm:lowerLimit uom="FL">100</aixm:lowerLimit>
                           <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                           <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="obs-sfc" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                            <aixm:Surface gml:id="uuid.626c2d10-d5ba-427e-a0c8-98949dd20a69" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                               <gml:polygonPatches>
                                 <gml:PolygonPatch>
                                   <gml:exterior>

--- a/3.0.0RC1/examples/airmet-translation-failed.xml
+++ b/3.0.0RC1/examples/airmet-translation-failed.xml
@@ -15,7 +15,7 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
-    gml:id="airmet-YUDD-201405151520Z"
+    gml:id="uuid.a587cca7-b8e1-4633-b3a5-7a0e5f6e50c9"
     permissibleUsage="OPERATIONAL"
     translatedBulletinID="TTAAiiCCCYYGGgg"
     translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
@@ -28,9 +28,9 @@
     status="NORMAL">
 
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-YUDD">
+        <aixm:Unit gml:id="uuid.500c55b8-3d10-40cb-8243-159b05ca0e98">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.6f05c703-4024-4ea2-85a2-6c4a1b2bb949">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDD FIC</aixm:name>
@@ -41,9 +41,9 @@
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="wmo-YUDD">
+        <aixm:Unit gml:id="uuid.8831a1d6-dff0-49c7-81d6-802055d5be01">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="wmo-YUDD-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.5d46b0da-40c0-4d6f-a331-10c05693ac7c">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDD MWO</aixm:name>
@@ -57,7 +57,7 @@
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
 
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp1">
+        <gml:TimePeriod gml:id="uuid.b1c4f44c-f702-43a8-95c7-79c5823d9dd0">
             <gml:beginPosition>2014-05-15T15:20:00</gml:beginPosition>
             <gml:endPosition>2014-05-15T18:00:00</gml:endPosition>
         </gml:TimePeriod>

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -16,37 +16,37 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="metar-YUDO-20120822163000Z"
+    gml:id="uuid.510df5de-fefb-4406-bafd-faab35333ec0"
     permissibleUsage="OPERATIONAL"
     status="NORMAL"
     automatedStation="false">
 
     <iwxxm:observation>
-        <om:OM_Observation gml:id="obs-03839-20120824T12Z">
+        <om:OM_Observation gml:id="uuid.461fc090-2f02-41ff-ba17-9df1e06fd759">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
             <!-- time at which the observation actually occured (same as issueTime) -->
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-201208221630Z">
+                <gml:TimeInstant gml:id="uuid.ee64f8d5-b0fd-44c9-9f6e-058adc46e425">
                     <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
 	    <!-- time at which the results of the observation are made available -->
 	    <om:resultTime xlink:href="#ti-201208221630Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-metar">
+                <metce:Process gml:id="uuid.2becf617-e334-4f4d-82e8-3cad6216291b">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
             <om:featureOfInterest>
                 <!-- featureOfInterest type and shape must refer to a point -->
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.5e5af852-ee73-4b6e-95ca-f176ca22cd5d">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                     <sf:sampledFeature>
                         <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+                        <aixm:AirportHeliport gml:id="uuid.143d63d9-15f5-442e-9bdc-1f3db93fb619">
                           <aixm:timeSlice>
-                            <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                            <aixm:AirportHeliportTimeSlice gml:id="uuid.75c3340c-3679-4e31-8aec-efdabe375d49">
                               <gml:validTime/>
                               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                               <aixm:designator>YUDO</aixm:designator>
@@ -58,7 +58,7 @@
                     </sf:sampledFeature>
                     <sams:shape>
                         <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                        <gml:Point gml:id="point-5225-3201" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                        <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                             <gml:pos>12.34 -12.34</gml:pos>
                         </gml:Point>
                     </sams:shape>
@@ -66,7 +66,7 @@
             </om:featureOfInterest>
             <!-- The result of the observation -->
             <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="or1" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">
                     <iwxxm:airTemperature uom="Cel">17.0</iwxxm:airTemperature>
                     <iwxxm:dewpointTemperature uom="Cel">16.0</iwxxm:dewpointTemperature>
                     <iwxxm:qnh uom="hPa">1018</iwxxm:qnh>
@@ -84,9 +84,9 @@
                     <iwxxm:rvr>
                         <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
                             <iwxxm:runway>
-                                <aixm:RunwayDirection gml:id="YUDO-runwaydir-12">
+                                <aixm:RunwayDirection gml:id="uuid.f920a641-0eba-4fa3-9411-5c50444a0aa3">
                                     <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="YUDO-runwaydir-12-ts">
+                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.23b637cb-c450-4a24-83dd-ec6b965fe71d">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>12</aixm:designator>
@@ -120,11 +120,11 @@
         </om:OM_Observation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="trend-fcst-1">
+        <om:OM_Observation gml:id="uuid.dec45946-ef95-48d5-bc7a-61c801255453">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
             <!-- time at which the forecast conditions actually occur -->
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208221630Z-201208221700Z">
+                <gml:TimePeriod gml:id="uuid.819b0c7a-133f-4029-b1d9-451be77e3c5f">
                     <gml:beginPosition>2012-08-22T16:30:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-22T17:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -135,7 +135,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="trend-fcst-record-03839-201208221630Z-201208221700Z" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">800</iwxxm:prevailingVisibility>
                     <iwxxm:forecastWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
                 </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
@@ -143,11 +143,11 @@
         </om:OM_Observation>
     </iwxxm:trendForecast>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="trend-fcst-2">
+        <om:OM_Observation gml:id="uuid.69a3657a-b0b5-4b12-95de-ce13422b5d86">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
             <!-- time at which the forecast conditions actually occur -->
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208221800Z-201208221800Z">
+                <gml:TimePeriod gml:id="uuid.d4d26581-aea9-4caf-abb3-0304faac191b">
                     <gml:beginPosition>2012-08-22T18:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-22T18:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -158,7 +158,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="trend-fcst-record-03839-201208221800Z-201208221900Z" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.be66f283-6aae-4a84-bc84-3831c9b2e7ef" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
                     <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
                     <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>

--- a/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
+++ b/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
@@ -16,30 +16,30 @@
     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-    gml:id="metar-EDDF-20130312T055000Z" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
+    gml:id="uuid.96a5ba6a-47ce-4c10-bc56-355a32dcf22c" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
     <iwxxm:observation>
-        <om:OM_Observation gml:id="obs-EDDF-20130312T055000Z">
+        <om:OM_Observation gml:id="uuid.699aaad3-e7f0-42af-9203-79d9daf71b47">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-20130312T055000Z">
+                <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
                     <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <om:resultTime xlink:href="#ti-20130312T055000Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-metar">
+                <metce:Process gml:id="uuid.9413b38a-c725-4d18-8dad-4e3eb45f3818">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sp-EDDF">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.d7f17da6-7ead-4c19-95ab-449a7d5759cc">
                     <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                     <sam:sampledFeature>
                         <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="aerodrome-EDDF">
+                        <aixm:AirportHeliport gml:id="uuid.124c4e83-3137-450e-aab3-3259d92282fd">
                             <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-EDDF-ts">
+                                <aixm:AirportHeliportTimeSlice gml:id="uuid.7287c97c-321e-42df-8e50-d6068c6e12b0">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:designator>EDDF</aixm:designator>
@@ -50,7 +50,7 @@
                         </aixm:AirportHeliport>
                      </sam:sampledFeature>
                     <sams:shape>
-                        <gml:Point gml:id="obs-point-EDDF"
+                        <gml:Point gml:id="uuid.68f896c8-6889-4b5b-8d79-1f1216ceb72f"
                             uomLabels="deg deg m"
                             axisLabels="Lat Lon Altitude"
                             srsDimension="3"
@@ -63,7 +63,7 @@
             <om:result>
 
                 <iwxxm:MeteorologicalAerodromeObservationRecord cloudAndVisibilityOK="false"
-                    gml:id="observation-record-EDDF-20130312T055000Z">
+                    gml:id="uuid.5980a075-9a27-4da7-b657-8c8f7032f24c">
                     <iwxxm:airTemperature uom="Cel">-4</iwxxm:airTemperature>
                     <iwxxm:dewpointTemperature uom="Cel">-4</iwxxm:dewpointTemperature>
                     <iwxxm:qnh uom="hPa">1000</iwxxm:qnh>
@@ -112,9 +112,9 @@
                     <iwxxm:runwayState>
                         <iwxxm:AerodromeRunwayState>
                             <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="runway-eddf-07-r-sf">
+                                <aixm:RunwayDirection  gml:id="uuid.f1ff030c-1e4c-40a5-be9a-fbb714369f7f">
                                     <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="runway-eddf-07-r-sf-ts">
+                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.0c695aa2-df15-421d-a616-ca510b356098">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>07R</aixm:designator>
@@ -131,9 +131,9 @@
                     <iwxxm:runwayState>
                         <iwxxm:AerodromeRunwayState>
                             <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="runway-EDDF-07-c-sf">
+                                <aixm:RunwayDirection  gml:id="uuid.46f64d66-03fb-4469-85a2-ab712aa8a7ff">
                                     <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="runway-EDDF-07-c-sf-ts">
+                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.26b44940-55b0-4f4f-805c-3b40af52694e">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>07C</aixm:designator>
@@ -150,9 +150,9 @@
                     <iwxxm:runwayState>
                         <iwxxm:AerodromeRunwayState>
                             <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="runway-EDDF-07-l-sf">
+                                <aixm:RunwayDirection  gml:id="uuid.fa34a796-e0d1-409d-a544-90d6787d46ca">
                                     <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="runway-EDDF-07-l-sf-ts">
+                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.6c4abb3b-e4a0-48e0-a058-314c3f2ef3e6">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>07L</aixm:designator>
@@ -172,7 +172,7 @@
         </om:OM_Observation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="trend-fcst-1">
+        <om:OM_Observation gml:id="uuid.8dfbd54a-a482-4fe3-bc32-1ca3794b9f14">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
             <om:phenomenonTime nilReason="unknown"/>
             <om:resultTime xlink:href="#ti-20130312T055000Z"/>
@@ -180,7 +180,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
             <om:featureOfInterest xlink:href="#sp-EDDF"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="trend-fcst-record-1-201303120550Z-201303120750Z" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.83222aab-9e5f-4296-a7f5-3d7e2af4ae45" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">4000</iwxxm:prevailingVisibility>
                     <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
                 </iwxxm:MeteorologicalAerodromeTrendForecastRecord>

--- a/3.0.0RC1/examples/metar-LKKV.xml
+++ b/3.0.0RC1/examples/metar-LKKV.xml
@@ -11,29 +11,29 @@
     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-    gml:id="metar-LKKV-20070725T12Z" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
+    gml:id="uuid.ce3b61b9-d360-4da1-83b9-67e668406869" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
     <iwxxm:observation>
-        <om:OM_Observation gml:id="obs-LKKV-20070725T120000Z">
+        <om:OM_Observation gml:id="uuid.f1ee2439-7dc2-478d-9a42-1a4577e83146">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-20070725T12Z">
+                <gml:TimeInstant gml:id="uuid.27e26b04-27e7-4c41-adaa-2b16ba92e310">
                     <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <om:resultTime xlink:href="#ti-20070725T12Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-metar">
+                <metce:Process gml:id="uuid.a931097a-48a9-4f31-99c3-ed4ca3da8c09">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sp-LKKV">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.77f712fd-f7fd-4762-812a-70acc7103af5">
                     <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                     <sam:sampledFeature>
-                        <aixm:AirportHeliport gml:id="aerodrome-LKKV">
+                        <aixm:AirportHeliport gml:id="uuid.249725b7-1d1f-4431-8ff0-bbbe65c5f5c0">
                             <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-LKKV-ts">
+                                <aixm:AirportHeliportTimeSlice gml:id="uuid.c69cbe8a-81da-4ddc-a4a8-995e052327d2">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:designator>LKKV</aixm:designator>
@@ -44,14 +44,14 @@
                         </aixm:AirportHeliport>
                     </sam:sampledFeature>
                     <sams:shape>
-                        <gml:Point gml:id="obs-point-LKKV" uomLabels="deg deg m" axisLabels="Lat Lon Altitude" srsDimension="3" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+                        <gml:Point gml:id="uuid.70c31fd7-c5cf-4c64-ad24-67f2ce15b0e6" uomLabels="deg deg m" axisLabels="Lat Lon Altitude" srsDimension="3" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
                             <gml:pos>50.20 12.92 606</gml:pos>
                         </gml:Point>
                     </sams:shape>
                 </sams:SF_SpatialSamplingFeature>
             </om:featureOfInterest>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord cloudAndVisibilityOK="false" gml:id="observation-record-LKKV-20070725T12Z">
+                <iwxxm:MeteorologicalAerodromeObservationRecord cloudAndVisibilityOK="false" gml:id="uuid.dccac4d8-c332-4353-997b-822db356eafa">
                     <iwxxm:airTemperature uom="Cel">27</iwxxm:airTemperature>
                     <iwxxm:dewpointTemperature uom="Cel">10</iwxxm:dewpointTemperature>
                     <iwxxm:qnh uom="hPa">1010</iwxxm:qnh>
@@ -67,9 +67,9 @@
                     <iwxxm:windShear>
                       <iwxxm:AerodromeWindShear>
                         <iwxxm:runway>
-                          <aixm:RunwayDirection gml:id="LKKV-R18C">
+                          <aixm:RunwayDirection gml:id="uuid.3f6809e8-12e1-49ec-a2de-a714fd66fd07">
                             <aixm:timeSlice>
-                              <aixm:RunwayDirectionTimeSlice gml:id="LKKV-R18C-ts">
+                              <aixm:RunwayDirectionTimeSlice gml:id="uuid.6e500b68-defe-453a-8569-e6efa8d903f1">
                                 <gml:validTime/>
                                 <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                 <aixm:designator>18C</aixm:designator>
@@ -82,9 +82,9 @@
                   <iwxxm:runwayState>
                         <iwxxm:AerodromeRunwayState>
                             <iwxxm:runway>
-                              <aixm:RunwayDirection gml:id="LKKV-R11">
+                              <aixm:RunwayDirection gml:id="uuid.4ce3040f-69a1-4703-8a21-78a33c14ddce">
                                   <aixm:timeSlice>
-                                      <aixm:RunwayDirectionTimeSlice gml:id="LKKV-R11-ts">
+                                      <aixm:RunwayDirectionTimeSlice gml:id="uuid.da0eb705-ba52-4d66-8d0d-130b99be5692">
                                           <gml:validTime/>
                                           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                           <aixm:designator>11</aixm:designator>

--- a/3.0.0RC1/examples/metar-NIL-collect.xml
+++ b/3.0.0RC1/examples/metar-NIL-collect.xml
@@ -20,42 +20,42 @@
                         http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
 			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
 			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
-    gml:id="uuid.ce2f37bd-2d9e-4864-896c-bc7f0174aa5b">
+    gml:id="uuid.6f353602-12a1-40a7-b6b5-3edb14c6241e">
 
     <collect:meteorologicalInformation>
 
         <iwxxm:METAR 
-            gml:id="metar-YUDO-20120822163000Z"
+            gml:id="uuid.15ff064a-6dc4-41e0-bafa-8ee78ed4dc25"
             status="MISSING"
             permissibleUsage="OPERATIONAL"
             automatedStation="false">
         
             <iwxxm:observation>
-                <om:OM_Observation gml:id="obs-03839-20120824T12Z">
+                <om:OM_Observation gml:id="uuid.81ac9ff7-a1ba-4124-a8fe-bc29794cd381">
                     <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
                     <!-- time at which the observation of the missing should occur (same as issueTime) -->
                     <om:phenomenonTime>
-                        <gml:TimeInstant gml:id="ti-201208221630Z">
+                        <gml:TimeInstant gml:id="uuid.63a9f14f-f5bd-4b7f-a5b4-df85ecad4c32">
                             <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
                         </gml:TimeInstant>
                     </om:phenomenonTime>
                     <!-- time at which the results of the observation are made available -->
 		    <om:resultTime xlink:href="#ti-201208221630Z"/>
 		    <om:procedure>
-                        <metce:Process gml:id="p-49-2-metar">
+                        <metce:Process gml:id="uuid.f1b88806-76ad-41a7-8d18-55dfd332a98c">
                             <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
                         </metce:Process>
                     </om:procedure>
                     <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
                     <om:featureOfInterest>
                         <!-- featureOfInterest type and shape must refer to a point -->
-                        <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+                        <sams:SF_SpatialSamplingFeature gml:id="uuid.4161385c-f76e-484b-b092-035355cf38c1">
                             <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                             <sf:sampledFeature>
                                 <!-- The aerodrome at which this observation took place -->
-                                <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+                                <aixm:AirportHeliport gml:id="uuid.2cb49495-cbc5-4bc8-aaf6-334fd9268391">
                                     <aixm:timeSlice>
-                                        <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                                        <aixm:AirportHeliportTimeSlice gml:id="uuid.1c046a98-8714-4038-b5fc-46c97bac0f4f">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>YUDO</aixm:designator>
@@ -67,7 +67,7 @@
                             </sf:sampledFeature>
                             <sams:shape>
                                 <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                                <gml:Point gml:id="point-5225-3201" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                <gml:Point gml:id="uuid.c3de1912-8b52-4c98-b201-0b4208f9bac1" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                                     <gml:pos>12.34 -12.34</gml:pos>
                                 </gml:Point>
                             </sams:shape>

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -13,7 +13,7 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="metar-YUDO-201208160000Z"
+    gml:id="uuid.4324ada0-ddfc-4206-9689-3aa8b58649fd"
     permissibleUsage="OPERATIONAL"
     translatedBulletinID="TTAAiiCCCYYGGgg"
     translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
@@ -24,31 +24,31 @@
     status="NORMAL">
   
   <iwxxm:observation>
-    <om:OM_Observation gml:id="obs-03839-20120824T12Z">
+    <om:OM_Observation gml:id="uuid.cab9a958-ddbe-4ec3-818e-20c8088a2ab6">
       <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="ti-201208221630Z">
+        <gml:TimeInstant gml:id="uuid.46784d6c-e625-4ea7-86cc-a3cc1bdbe4b4">
           <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
       <om:resultTime>
-        <gml:TimeInstant gml:id="ti-201208221640Z">
+        <gml:TimeInstant gml:id="uuid.3df8b70f-ba69-4ed0-a45e-e46a8009b674">
           <gml:timePosition>2012-08-22T16:40:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:resultTime>
       <om:procedure>
-        <metce:Process gml:id="p-49-2-metar">
+        <metce:Process gml:id="uuid.aa8790c9-7745-48a2-9b87-3d7c6c576a42">
           <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
         </metce:Process>
       </om:procedure>
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
       <om:featureOfInterest>
-        <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+        <sams:SF_SpatialSamplingFeature gml:id="uuid.a562f2e4-b2c9-44c3-9c63-f96cbbb4b11c">
           <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
           <sf:sampledFeature>
-            <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+            <aixm:AirportHeliport gml:id="uuid.7a8db8f9-281a-40ca-a443-40253790bfff">
               <aixm:timeSlice>
-                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.6656af3d-e836-49d9-a7f1-f8c8b23790f9">
                   <gml:validTime/>
                   <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                   <aixm:designator>YUDO</aixm:designator>

--- a/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
@@ -15,14 +15,14 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="sigmet-YUDD-201208101200Z"
+    gml:id="uuid.8debfaca-7116-4b32-9378-b472ca64e823"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-YUDD">
+        <aixm:Unit gml:id="uuid.fb27bee4-d1a0-4e47-87b3-7dbd863a55bf">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.83c6260a-67c8-46f9-ab95-5f8ea92c3236">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDD FIC</aixm:name>
@@ -33,9 +33,9 @@
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="wmo-YUSO">
+        <aixm:Unit gml:id="uuid.104eed56-d042-40b1-8704-484da1e47070">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="mwo-YUSO-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.2bb4af1b-ad05-4be3-b9e4-a1a7848a0180">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUSO MWO</aixm:name>
@@ -50,7 +50,7 @@
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp-20120810T1200Z-20120810T1600Z">
+        <gml:TimePeriod gml:id="uuid.18e9591a-b3f0-4927-b723-b4f66d7c386f">
             <gml:beginPosition>2012-08-10T12:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-10T16:00:00Z</gml:endPosition>
         </gml:TimePeriod>
@@ -61,33 +61,33 @@
 
     <!-- FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="analysis1">
+        <om:OM_Observation gml:id="uuid.3c96a88a-8388-40d3-8d1d-fb5f69d071d7">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
             <!-- time of FCST conditions - if missing there is no FCST or OBS time -->
             <om:phenomenonTime nilReason="missing"/>
 
             <!-- time at which the results of the observation were made available -->
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-201208101200Z">
+                <gml:TimeInstant gml:id="uuid.7754148a-7769-4adc-93fc-d591bf19c715">
                     <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <!-- The valid period for this observation is the period of the entire SIGMET -->
             <om:validTime xlink:href="#tp-20120810T1200Z-20120810T1600Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-sigmet">
+                <metce:Process gml:id="uuid.e5f851f2-4e6d-4656-bd45-77fc6fdc6388">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
             <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-surface-shanlon">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.44664773-df86-400b-9c97-37764b7245ba">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
                     <sf:sampledFeature>
-                        <aixm:Airspace gml:id="fir-YUDD">
+                        <aixm:Airspace gml:id="uuid.e8411dad-219a-4018-ad55-c5791a87c86d">
                             <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="fir-YUDD-ts">
+                                <aixm:AirspaceTimeSlice gml:id="uuid.de6d3114-bafe-47d6-a47f-2fbe43581a54">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:type>OTHER:FIR_UIR</aixm:type>
@@ -102,17 +102,17 @@
                 </sams:SF_SpatialSamplingFeature>
             </om:featureOfInterest>
             <om:result>
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="fcst1" timeIndicator="FORECAST">
+                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.06446fea-1935-4101-b3e8-74f286a9b74d" timeIndicator="FORECAST">
                   <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="sec1" intensityChange="WEAKEN">
+                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.10f68782-703d-43a6-a4e5-af27469edc6e" intensityChange="WEAKEN">
                       <iwxxm:directionOfMotion uom="deg">90</iwxxm:directionOfMotion>
                       <!-- This shape describes: S OF N54 AND E OF W012 TOP FL390 -->
                       <iwxxm:geometry>
-                        <aixm:AirspaceVolume gml:id="as1">
+                        <aixm:AirspaceVolume gml:id="uuid.d4938cc8-c129-4cd7-bda5-588c434ef996">
                           <aixm:upperLimit uom="FL">390</aixm:upperLimit>
                           <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                           <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="sfc1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                            <aixm:Surface gml:id="uuid.e20caa4b-2b93-4d28-9b14-e04196314999" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                               <gml:polygonPatches>
                                 <gml:PolygonPatch>
                                   <gml:exterior>

--- a/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
@@ -15,14 +15,14 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="sigmet-YUDD-201208101345Z"
+    gml:id="uuid.6fe37ba5-7ad5-471a-ac44-48ddefb2c23f"
     permissibleUsage="OPERATIONAL"
     status="CANCELLATION">
 
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-YUDD">
+        <aixm:Unit gml:id="uuid.e4f83cc7-2f15-441d-97dc-2ba9f3825a8e">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.a1333c4a-23d0-4966-97dc-1d8cadc24e72">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDD FIC</aixm:name>
@@ -34,9 +34,9 @@
     </iwxxm:issuingAirTrafficServicesUnit>
 
     <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="wmo-YUSO">
+        <aixm:Unit gml:id="uuid.488a352b-2928-4514-a578-a1382d213b18">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="mwo-YUSO-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.62d0a959-3e4d-4fa3-84b9-f7d1211810ea">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUSO MWO</aixm:name>
@@ -51,7 +51,7 @@
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp-20120810T1345Z-20120810T1600Z">
+        <gml:TimePeriod gml:id="uuid.b1c68261-5b7d-4b39-9458-fbc92d8dc326">
             <gml:beginPosition>2012-08-10T13:45:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-10T16:00:00Z</gml:endPosition>
         </gml:TimePeriod>
@@ -60,7 +60,7 @@
     <iwxxm:cancelledSequenceNumber>2</iwxxm:cancelledSequenceNumber>
 
     <iwxxm:cancelledValidPeriod>
-        <gml:TimePeriod gml:id="tp-20120810T1200Z-20120810T1600Z">
+        <gml:TimePeriod gml:id="uuid.ad79d14d-6bd9-46b6-aaf0-e99b2c85ccf9">
             <gml:beginPosition>2012-08-10T12:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-10T16:00:00Z</gml:endPosition>
         </gml:TimePeriod>
@@ -69,28 +69,28 @@
     <iwxxm:phenomenon nilReason="inapplicable"/>
 
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="seca1">
+        <om:OM_Observation gml:id="uuid.7c75707a-b0e9-4784-b6d9-5218c055e8ca">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
             <om:phenomenonTime nilReason="inapplicable"/>
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-20120810T1345Z">
+                <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
                     <gml:timePosition>2012-08-10T13:45:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:validTime xlink:href="#tp-20120810T1345Z-20120810T1600Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-sigmet">
+                <metce:Process gml:id="uuid.05a38462-4063-466d-9010-413a085f3407">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-surface-Amswell">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.081f550e-29e2-42cb-8f9a-cb3f02c53d1f">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
                     <sf:sampledFeature>
-                        <aixm:Airspace gml:id="fir-YUDD">
+                        <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
                             <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="fir-YUDD-ts">
+                                <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:type>OTHER:FIR_UIR</aixm:type>

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -16,14 +16,14 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="sigmet-YUCC-20120825160000Z"
+    gml:id="uuid.f12194be-0d82-49ad-ad97-41e46f724dec"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-YUCC">
+        <aixm:Unit gml:id="uuid.ee9eedf1-52d2-45b4-8f7c-f027dd25c5e6">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="fic-YUCC-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.608b9022-1c51-4729-bd89-67543b3d7d68">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUCC FIC</aixm:name>
@@ -34,9 +34,9 @@
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="wmo-YUDO">
+        <aixm:Unit gml:id="uuid.d8835dc7-18db-424e-929a-e4c79be92cad">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="mwo-YUDO-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.0fac05ad-b4c5-49df-9e88-31fe413d087a">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDO MWO</aixm:name>
@@ -51,7 +51,7 @@
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp-20120825T1600Z-20120825T2200Z">
+        <gml:TimePeriod gml:id="uuid.d26ff125-63ea-4cd8-b2cf-75629b9ecbe3">
             <gml:beginPosition>2012-08-25T16:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-25T22:00:00Z</gml:endPosition>
         </gml:TimePeriod>
@@ -62,36 +62,36 @@
 
     <!-- OBS AT 1600Z -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="analysis-20120825T1600Z">
+        <om:OM_Observation gml:id="uuid.4cd84f41-edbf-4dc6-ba67-88048d9d1368">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
             <!-- time of observed conditions -->
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-201208251600Z">
+                <gml:TimeInstant gml:id="uuid.2f6d2369-b614-4522-8c76-bc44d770ce5e">
                     <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <!-- time at which the results of the observation were made available -->
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-201208251600Z2">
+                <gml:TimeInstant gml:id="uuid.f598d1e0-8e2d-4af1-a4ee-83d04b37f19e">
                     <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <!-- The valid period for this observation is the period of the entire SIGMET -->
             <om:validTime xlink:href="#tp-20120825T1600Z-20120825T2200Z"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-sigmet">
+                <metce:Process gml:id="uuid.7cb644bf-d7d8-4842-803e-84cc4de4e8f0">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
             <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-surface-Amswell">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.8eb74801-27b9-4e74-8704-5bfa18ded253">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
                     <sf:sampledFeature>
-                        <aixm:Airspace gml:id="fir-YUCC">
+                        <aixm:Airspace gml:id="uuid.83b13711-6bf4-4497-9293-6bb5490bc259">
                             <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="fir-YUCC-ts">
+                                <aixm:AirspaceTimeSlice gml:id="uuid.44f4afb1-fab4-4d01-8030-7d51b43eb4ed">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:type>FIR</aixm:type>
@@ -107,23 +107,23 @@
             </om:featureOfInterest>
             <om:result>
                 <!-- CB OBS AT 1600Z WI 250NM OF TC CENTRE TOP FL500 NC -->
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="tc-obs-N2706" timeIndicator="OBSERVATION">
+                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.89147e42-7ce0-493e-b81d-6ba6a989e8a1" timeIndicator="OBSERVATION">
                   <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="tc-sec1" intensityChange="NO_CHANGE">
+                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.c0a23437-9eb7-4e6b-82f2-6fbd5757440c" intensityChange="NO_CHANGE">
                       <!-- This shape describes:
                           N2706 W07306 CB TOP FL500 WI 150NM OF CENTRE i.e., a 150NM radius around -73.10 (lon), 27.10 (lat) -->
                       <iwxxm:geometry>
-                          <aixm:AirspaceVolume gml:id="as1">
+                          <aixm:AirspaceVolume gml:id="uuid.08077323-fbd5-4e04-a787-fccff0543f0a">
                               <aixm:upperLimit uom="FL">500</aixm:upperLimit>
                               <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                               <aixm:horizontalProjection>
-                                  <aixm:Surface gml:id="tc-obs-N2706-sfc" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                  <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                                       <gml:polygonPatches>
                                           <gml:PolygonPatch>
                                               <gml:exterior>
                                                   <gml:Ring>
                                                       <gml:curveMember>
-                                                          <gml:Curve gml:id="curve01">
+                                                          <gml:Curve gml:id="uuid.b7fa4047-2e78-431c-ba95-3fdf6343e3b5">
                                                               <gml:segments>
                                                                   <gml:CircleByCenterPoint numArc="1">
                                                                       <gml:pos>27.10 -73.10</gml:pos>
@@ -149,17 +149,17 @@
 
     <!-- FCST AT 2200Z TC CENTRE PSN N2740 W07345 -->
     <iwxxm:forecastPositionAnalysis>
-        <om:OM_Observation gml:id="analysis-20120825T1600Z2">
+        <om:OM_Observation gml:id="uuid.caee76a0-bb11-48d3-b1cb-d916302dc81d">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
             <!-- time of forecast conditions -->
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-20120825T1600Z2">
+                <gml:TimeInstant gml:id="uuid.aab0df0d-6ee9-4ff8-82b2-06a2a42ab0a9">
                     <gml:timePosition>2012-08-25T22:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <!-- time at which the results of the observation were made available -->
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-201208251600Z3">
+                <gml:TimeInstant gml:id="uuid.b76d57ea-3648-4d91-8d71-6b627424b16c">
                     <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
@@ -169,20 +169,20 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
             <om:featureOfInterest xlink:href="#sampling-surface-Amswell"/>
             <om:result>
-                <iwxxm:SIGMETPositionCollection gml:id="position-collection-result-2">
+                <iwxxm:SIGMETPositionCollection gml:id="uuid.59824907-bcbe-476d-8151-8743e4a1b7db">
                     <iwxxm:member>
                         <!-- TC CENTRE N2740 W07345 -->
-                        <iwxxm:SIGMETPosition gml:id="sigmet-fcst-N2706">
+                        <iwxxm:SIGMETPosition gml:id="uuid.338354de-7634-4fca-ac75-3675cb592284">
                             <iwxxm:geometry>
-                                <aixm:AirspaceVolume gml:id="as2">
+                                <aixm:AirspaceVolume gml:id="uuid.4ed35f91-7189-4b9c-baed-19b5cec0b4c1">
                                     <aixm:horizontalProjection>
-                                        <aixm:Surface gml:id="sfc002" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                        <aixm:Surface gml:id="uuid.c76ff9fa-ec6b-48ed-8f26-ed37c47bbc38" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                                             <gml:polygonPatches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:Ring>
                                                             <gml:curveMember>
-                                                                <gml:Curve gml:id="curve001">
+                                                                <gml:Curve gml:id="uuid.0380d35a-1d35-46a2-bbc8-38190206bfe8">
                                                                     <gml:segments>
                                                                         <gml:CircleByCenterPoint numArc="1">
                                                                             <gml:pos>27.6667 -73.75</gml:pos>
@@ -207,7 +207,7 @@
     </iwxxm:forecastPositionAnalysis>
 
     <iwxxm:tropicalCyclone>
-        <metce:TropicalCyclone gml:id="TC-Gloria">
+        <metce:TropicalCyclone gml:id="uuid.c529d539-2fa9-428d-937a-867e50056f16">
             <metce:name>Gloria</metce:name>
         </metce:TropicalCyclone>
     </iwxxm:tropicalCyclone>

--- a/3.0.0RC1/examples/sigmet-VA-EGGX.xml
+++ b/3.0.0RC1/examples/sigmet-VA-EGGX.xml
@@ -17,13 +17,13 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-    gml:id="va-sigmet-EGGX-YYYYMM25T160000Z"
+    gml:id="uuid.64c3912b-b09a-494a-8731-321f28b759e4"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
     <iwxxm:issuingAirTrafficServicesUnit>
-        <aixm:Unit gml:id="fic-EGGX">
+        <aixm:Unit gml:id="uuid.cdca7fc8-2ca0-42fd-b335-822e3f8c7921">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="fic-EGGX-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.653f575e-ed12-4e93-8ce6-ec0b3ab0f413">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>SHANWICK OCEANIC AREA CONTROL CENTRE</aixm:name>
@@ -34,9 +34,9 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="wmo-EGRR">
+        <aixm:Unit gml:id="uuid.358af98d-e353-480c-880d-c94000fe8341">
             <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="mwo-EGRR-ts">
+                <aixm:UnitTimeSlice gml:id="uuid.a0db8cf4-6f8c-4c2c-a7ad-ea44a87dc095">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>UK METEOROLOGICAL OFFICE - EXETER</aixm:name>
@@ -48,35 +48,35 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
     </iwxxm:originatingMeteorologicalWatchOffice>
     <iwxxm:sequenceNumber>4</iwxxm:sequenceNumber>
     <iwxxm:validPeriod>
-        <gml:TimePeriod gml:id="tp-25T16Z-25T22Z">
+        <gml:TimePeriod gml:id="uuid.099bfa3a-0fb2-4a79-87f5-076fa28e6711">
             <gml:beginPosition>YYYY-MM-25T16:00:00Z</gml:beginPosition>
             <gml:endPosition>YYYY-MM-25T22:00:00Z</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validPeriod>
     <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SigWxPhenomena/VA"/>
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="va-position-and-motion-EGGX-YYYYMM25T16Z">
+        <om:OM_Observation gml:id="uuid.94838606-4ec4-437c-9be1-901b8e7a33c6">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-25T16Z">
+                <gml:TimeInstant gml:id="uuid.0fff6dbb-ba23-4794-810e-d2b79c895053">
                     <gml:timePosition>YYYY-MM-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <om:resultTime xlink:href="#ti-25T16Z"/>
 	    <om:validTime xlink:href="#tp-25T16Z-25T22Z"/>
 	    <om:procedure>
-                <metce:Process gml:id="p-49-2-va-sigmet">
+                <metce:Process gml:id="uuid.73b043ca-bb18-446b-9118-2577d1422dcb">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation [C.3.1.]7 SIGMET AND AIRMET INFORMATION, AERODROME WARNINGS AND WIND SHEAR WARNINGS AND ALERTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
             <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="ss-SHANWICK_OCA">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.9b1c2b6f-33ac-46d7-9c91-d85d50d84063">
                     <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
                     <sam:sampledFeature>
-                        <aixm:Airspace gml:id="fir-EGGX">
+                        <aixm:Airspace gml:id="uuid.1fa42185-604c-4a56-a578-d1eb07109c38">
                             <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="fir-EGGX-ts">
+                                <aixm:AirspaceTimeSlice gml:id="uuid.df98083d-660a-45be-9292-8037b13da46c">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:type>FIR</aixm:type>
@@ -91,17 +91,17 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                 </sams:SF_SpatialSamplingFeature>
             </om:featureOfInterest>
             <om:result>
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="emc-va-obs-EGGX-YYYYMM25T16Z" timeIndicator="OBSERVATION">
+                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.fb90468d-60bb-4828-99ed-3ff730759ac3" timeIndicator="OBSERVATION">
                   <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="sec1" intensityChange="NO_CHANGE">
+                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.b3f301d8-e8b4-4d24-91b1-78f52672edcb" intensityChange="NO_CHANGE">
                       <iwxxm:directionOfMotion uom="deg">180</iwxxm:directionOfMotion>
                       <iwxxm:geometry>
-                        <aixm:AirspaceVolume gml:id="av-va-obs-position-EGGX-YYYYMM25T16Z">
+                        <aixm:AirspaceVolume gml:id="uuid.6a77deae-62d5-43c0-99df-c40a6ddf4e3f">
                           <!-- omitted lower-limit implies that the volcanic ash cloud extends to ground/sea surface -->
                           <aixm:upperLimit uom="FL">550</aixm:upperLimit>
                           <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                           <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="polygon-va-obs-position-EGGX-YYYYMM25T16Z"
+                            <aixm:Surface gml:id="uuid.99f0ea38-755d-4435-b7c7-7cc5afcce237"
                               uomLabels="deg deg"
                               axisLabels="Lat Lon"
                               srsDimension="2"
@@ -133,10 +133,10 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
         </om:OM_Observation>
     </iwxxm:analysis>
     <iwxxm:forecastPositionAnalysis>
-        <om:OM_Observation gml:id="va-forecast-position-EGGX-YYYYMM25T22Z">
+        <om:OM_Observation gml:id="uuid.cc6dcc03-dc8a-4185-b36b-b3282e07fbdf">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-25T22Z">
+                <gml:TimeInstant gml:id="uuid.8176a547-141d-471f-b12f-10b7338dadbe">
                     <gml:timePosition>YYYY-MM-25T22:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
@@ -146,13 +146,13 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
             <om:featureOfInterest xlink:href="#ss-SHANWICK_OCA"/>
             <om:result>
-                <iwxxm:SIGMETPositionCollection gml:id="mpc-EGGX-YYYYMM25T16Z">
+                <iwxxm:SIGMETPositionCollection gml:id="uuid.a76bad9a-9d0b-45ea-82ed-c5f697b9d68a">
                     <iwxxm:member>
-                        <iwxxm:SIGMETPosition gml:id="mp-va-fcst-EGGX-YYYYMM25T16Z">
+                        <iwxxm:SIGMETPosition gml:id="uuid.fefac6d8-d236-4008-ad4d-cc8b229b7c50">
                             <iwxxm:geometry>
-                                <aixm:AirspaceVolume gml:id="av-va-fcst-position-EGGX-YYYYMM25T22Z">
+                                <aixm:AirspaceVolume gml:id="uuid.e985f12a-5e11-433c-aa5e-699eecb0c244">
                                     <aixm:horizontalProjection>
-                                        <aixm:Surface gml:id="polygon-va-fcst-position-EGGX-YYYYMM25T22Z" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                        <aixm:Surface gml:id="uuid.a667da6f-fb8a-4029-93f3-509ab9408220" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                                             <gml:polygonPatches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
@@ -179,10 +179,10 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
         </om:OM_Observation>
     </iwxxm:forecastPositionAnalysis>
     <iwxxm:eruptingVolcano>
-        <metce:Volcano gml:id="v-MT-HEKLA">
+        <metce:Volcano gml:id="uuid.99646618-9ec7-47c0-8b50-daba5b6b1da9">
             <metce:name>MT HEKLA</metce:name>
             <metce:position>
-                <gml:Point gml:id="ref-point-MT-HEKLA" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                <gml:Point gml:id="uuid.ff6b0574-ed4a-44ee-9508-316eb8badd66" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                     <gml:pos>63.98 -19.67</gml:pos>
                 </gml:Point>
             </metce:position>

--- a/3.0.0RC1/examples/sigmet-multi-location.xml
+++ b/3.0.0RC1/examples/sigmet-multi-location.xml
@@ -21,13 +21,13 @@
   xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
   http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
   http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="va-sigmet-YUDD-YYYYMM10T120000Z"
+  gml:id="uuid.b4d56d93-3866-4f75-b493-da9a4bb2404c"
   permissibleUsage="OPERATIONAL"
   status="NORMAL">
   <iwxxm:issuingAirTrafficServicesUnit>
-    <aixm:Unit gml:id="fic-YUDD">
+    <aixm:Unit gml:id="uuid.37f89b19-7774-496b-a20d-f30627c45d17">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+        <aixm:UnitTimeSlice gml:id="uuid.c01e968b-77b1-4cfd-aedb-50d37f09c345">
           <gml:validTime/>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:name>SHANWICK OCEANIC AREA CONTROL CENTRE</aixm:name>
@@ -38,9 +38,9 @@
     </aixm:Unit>
   </iwxxm:issuingAirTrafficServicesUnit>
   <iwxxm:originatingMeteorologicalWatchOffice>
-    <aixm:Unit gml:id="wmo-YUSO">
+    <aixm:Unit gml:id="uuid.252469f5-d46a-41b4-a932-87e37328c474">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="mwo-YUSO-ts">
+        <aixm:UnitTimeSlice gml:id="uuid.58703e69-de03-41b8-b18c-9209e37aff94">
           <gml:validTime/>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:name>UK METEOROLOGICAL OFFICE - EXETER</aixm:name>
@@ -52,7 +52,7 @@
   </iwxxm:originatingMeteorologicalWatchOffice>
   <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
   <iwxxm:validPeriod>
-    <gml:TimePeriod gml:id="tp-10T12Z-10T22Z">
+    <gml:TimePeriod gml:id="uuid.06f1383c-c034-4ae0-9459-a0b99a3612a9">
       <gml:beginPosition>YYYY-MM-10T12:00:00Z</gml:beginPosition>
       <gml:endPosition>YYYY-MM-10T18:00:00Z</gml:endPosition>
     </gml:TimePeriod>
@@ -61,28 +61,28 @@
   <!-- VA CLD OBS AT 1200Z WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC
                        AND WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
   <iwxxm:analysis>
-    <om:OM_Observation gml:id="va-position-and-motion-YUDD-YYYYMM10T12Z">
+    <om:OM_Observation gml:id="uuid.be132ece-3217-4448-866d-d47feeb7914d">
       <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="ti-10T12Z">
+        <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
           <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
       <om:resultTime xlink:href="#ti-10T12Z"/>
       <om:validTime xlink:href="#tp-10T12Z-10T22Z"/>
       <om:procedure>
-        <metce:Process gml:id="p-49-2-va-sigmet">
+        <metce:Process gml:id="uuid.44a28548-e50b-44dd-93a2-acb32843dc8e">
           <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation [C.3.1.]7 SIGMET AND AIRMET INFORMATION, AERODROME WARNINGS AND WIND SHEAR WARNINGS AND ALERTS</gml:description>
         </metce:Process>
       </om:procedure>
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
       <om:featureOfInterest>
-        <sams:SF_SpatialSamplingFeature gml:id="ss-SHANWICK_OCA">
+        <sams:SF_SpatialSamplingFeature gml:id="uuid.066936d2-7d12-4447-9feb-b74fe3069490">
           <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
           <sam:sampledFeature>
-            <aixm:Airspace gml:id="fir-YUDD">
+            <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
               <aixm:timeSlice>
-                <aixm:AirspaceTimeSlice gml:id="fir-YUDD-ts">
+                <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
                   <gml:validTime/>
                   <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                   <aixm:type>OTHER:FIR_UIR</aixm:type>
@@ -97,19 +97,19 @@
         </sams:SF_SpatialSamplingFeature>
       </om:featureOfInterest>
       <om:result>
-        <iwxxm:SIGMETEvolvingConditionCollection gml:id="emc-va-obs-YUDD-YYYYMM10T12Z" timeIndicator="OBSERVATION">
+        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.ed862622-5643-4c5a-8922-01a04d18dbab" timeIndicator="OBSERVATION">
           <!-- WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC -->
           <iwxxm:member>
-            <iwxxm:SIGMETEvolvingCondition gml:id="mc-va-obs-YUDD-YYYYMM10T12Z1" intensityChange="NO_CHANGE">
+            <iwxxm:SIGMETEvolvingCondition gml:id="uuid.6cad5163-6a30-48a0-b723-2a14b5a93cc8" intensityChange="NO_CHANGE">
               <!-- N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 -->
               <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="av-va-obs-position-YUDD-YYYYMM10T12Z1">
+                <aixm:AirspaceVolume gml:id="uuid.8f3df57f-54a0-40dc-8c2d-b9cfe15f68fa">
                   <aixm:upperLimit uom="FL">370</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
                   <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="polygon-va-obs-position-YUDD-YYYYMM10T12Z1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
+                    <aixm:Surface gml:id="uuid.ca46d217-05d8-4f30-9ce0-b56b76af8d16" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
                       srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:polygonPatches>
                         <gml:PolygonPatch>
@@ -128,16 +128,16 @@
           </iwxxm:member>
           <!-- WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
           <iwxxm:member>
-            <iwxxm:SIGMETEvolvingCondition gml:id="mc-va-obs-YUDD-YYYYMM10T12Z2" intensityChange="NO_CHANGE">
+            <iwxxm:SIGMETEvolvingCondition gml:id="uuid.2425da44-f643-45c8-972c-ff122f50de80" intensityChange="NO_CHANGE">
               <!-- N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 -->
               <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="av-va-obs-position-YUDD-YYYYMM10T12Z2">
+                <aixm:AirspaceVolume gml:id="uuid.99d24aa8-6778-4356-be69-e91e529836ab">
                   <aixm:upperLimit uom="FL">300</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit uom="FL">150</aixm:lowerLimit>
                   <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="polygon-va-obs-position-YUDD-YYYYMM10T12Z2" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
+                    <aixm:Surface gml:id="uuid.4a5d7c8d-9ab3-402a-86ff-3889823df192" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
                       srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:polygonPatches>
                         <gml:PolygonPatch>
@@ -159,10 +159,10 @@
     </om:OM_Observation>
   </iwxxm:analysis>
   <iwxxm:forecastPositionAnalysis>
-    <om:OM_Observation gml:id="va-forecast-position-YUDD-YYYYMM10T22Z">
+    <om:OM_Observation gml:id="uuid.ee97301b-9177-4241-87eb-34c239621973">
       <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="ti-10T22Z">
+        <gml:TimeInstant gml:id="uuid.cce9b23a-d604-4194-8f73-2b7357ee4a9c">
           <gml:timePosition>YYYY-MM-10T18:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
@@ -172,14 +172,14 @@
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
       <om:featureOfInterest xlink:href="#ss-SHANWICK_OCA"/>
       <om:result>
-        <iwxxm:SIGMETPositionCollection gml:id="mpc-YUDD-YYYYMM10T12Z">
+        <iwxxm:SIGMETPositionCollection gml:id="uuid.fad0d2b4-7b60-4843-b17c-501f7b13efe0">
           <!-- APRX N4330 E02215 – N4315 E02345 – N4145 E02315 – N4230 E02200 - N4330 E02215 -->
           <iwxxm:member>
-            <iwxxm:SIGMETPosition gml:id="mp-va-fcst-YUDD-YYYYMM10T12Z1" approximateLocation="true">
+            <iwxxm:SIGMETPosition gml:id="uuid.a229e75e-9c12-4bac-a4d3-37eeaa99023f" approximateLocation="true">
               <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="av-va-fcst-position-YUDD-YYYYMM10T22Z1">
+                <aixm:AirspaceVolume gml:id="uuid.908afad2-34ae-49bf-8f7a-866961c781f1">
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="polygon-va-fcst-position-YUDD-YYYYMM10T22Z1" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <aixm:Surface gml:id="uuid.c5464381-23a9-4641-8a79-df05e394302e" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:polygonPatches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -197,11 +197,11 @@
           </iwxxm:member>
           <!-- APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E02130 - N4200 E02145 -->
           <iwxxm:member>
-            <iwxxm:SIGMETPosition gml:id="mp-va-fcst-YUDD-YYYYMM10T12Z2"  approximateLocation="true">
+            <iwxxm:SIGMETPosition gml:id="uuid.43b58951-4023-4805-97f3-bad21c4e6f74"  approximateLocation="true">
               <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="av-va-fcst-position-YUDD-YYYYMM10T22Z2">
+                <aixm:AirspaceVolume gml:id="uuid.c8c2ee62-3075-4642-89b9-8a84f28e510a">
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="polygon-va-fcst-position-YUDD-YYYYMM10T22Z2" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <aixm:Surface gml:id="uuid.c772f1bd-7684-4572-9907-7c742cc2013a" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:polygonPatches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -222,10 +222,10 @@
     </om:OM_Observation>
   </iwxxm:forecastPositionAnalysis>
   <iwxxm:eruptingVolcano>
-    <metce:Volcano gml:id="v-MT-ASHVAL">
+    <metce:Volcano gml:id="uuid.8c2bf282-1268-4066-bfc9-a56f7ae999f5">
       <metce:name>MT ASHVAL</metce:name>
       <metce:position>
-        <gml:Point gml:id="ref-point-MT-ASHVAL" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+        <gml:Point gml:id="uuid.2b5a1e46-9282-4912-a314-98ef9c65edae" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
           <gml:pos>43.15 21.15</gml:pos>
         </gml:Point>
       </metce:position>

--- a/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
+++ b/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
@@ -21,12 +21,12 @@
                         http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
 			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
 			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
-    gml:id="uuid.746c7ee2-09b6-4270-83b4-1dc167201c30">
+    gml:id="uuid.fee171e9-1aec-4815-bcca-9e3c467388c6">
 
     <collect:meteorologicalInformation>
 	
         <iwxxm:SIGMET 
-            gml:id="sigmet-YUDD-201208101200Z"
+            gml:id="uuid.636569b5-6b9b-4ed7-aa60-ad373a9e372b"
             permissibleUsage="OPERATIONAL"
             translatedBulletinID="WSYU31 YUSO 101000"
             translatedBulletinReceptionTime="2012-08-10T10:05:00Z"
@@ -38,9 +38,9 @@
             status="NORMAL">
         
             <iwxxm:issuingAirTrafficServicesUnit>
-              <aixm:Unit gml:id="fic-YUDD">
+              <aixm:Unit gml:id="uuid.8af40fb0-ea32-4192-81bf-f6f00b7d08b0">
                 <aixm:timeSlice>
-                  <aixm:UnitTimeSlice gml:id="fic-YUDD-ts">
+                  <aixm:UnitTimeSlice gml:id="uuid.bdc408dd-bc52-496c-9d68-26115d716188">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUDD FIC</aixm:name>
@@ -51,9 +51,9 @@
               </aixm:Unit>
             </iwxxm:issuingAirTrafficServicesUnit>
             <iwxxm:originatingMeteorologicalWatchOffice>
-              <aixm:Unit gml:id="wmo-YUSO">
+              <aixm:Unit gml:id="uuid.701a3f46-6b7b-4878-ad74-71436d8c953c">
                 <aixm:timeSlice>
-                  <aixm:UnitTimeSlice gml:id="mwo-YUSO-ts">
+                  <aixm:UnitTimeSlice gml:id="uuid.f99e1e20-003e-4605-bcfe-c1524a4cd7c2">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:name>YUSO MWO</aixm:name>
@@ -67,7 +67,7 @@
             <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
         
             <iwxxm:validPeriod>
-                <gml:TimePeriod gml:id="tp1">
+                <gml:TimePeriod gml:id="uuid.2635a879-81e5-4ac0-994f-b46050ba5e83">
                     <gml:beginPosition>2012-08-10T12:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-10T16:00:00Z</gml:endPosition>
                 </gml:TimePeriod>

--- a/3.0.0RC1/examples/speci-A3-2.xml
+++ b/3.0.0RC1/examples/speci-A3-2.xml
@@ -16,41 +16,41 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="speci-YUDO-20120822163000Z"
+    gml:id="uuid.8ca15300-d667-4364-86a1-ab8bec9ba833"
     status="NORMAL"
     permissibleUsage="OPERATIONAL"
     automatedStation="false">
 
     <iwxxm:observation>
-        <om:OM_Observation gml:id="obs-03839">
+        <om:OM_Observation gml:id="uuid.b218a1a4-2aa4-4047-969a-dbc5403b5091">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
             <!-- time at which the observation actually occured -->
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-201208151115">
+                <gml:TimeInstant gml:id="uuid.4929b573-d296-4261-bdf9-8d3e389ed72e">
                     <gml:timePosition>2012-08-15T11:15:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
             <!-- time at which the results of the observation were made available (10-minutes later) -->
             <om:resultTime>
-                <gml:TimeInstant gml:id="ti-2012081511125">
+                <gml:TimeInstant gml:id="uuid.cb26ec9c-bf49-401a-8385-cafdb23b2d40">
                     <gml:timePosition>2012-08-15T11:25:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-speci">
+                <metce:Process gml:id="uuid.53a0ae9b-d79d-4fb9-ad47-b320c0da2bf0">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
             <om:featureOfInterest>
                 <!-- featureOfInterest type and shape must refer to a point -->
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.9ec6d02d-9c90-4e8e-8844-91fb2c7eb2f6">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                     <sf:sampledFeature>
                         <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+                        <aixm:AirportHeliport gml:id="uuid.84a7fdc6-ff14-470c-a4b4-587688f02049">
                             <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                                <aixm:AirportHeliportTimeSlice gml:id="uuid.fa9959d1-8c30-4b1e-b854-bc0fcaed64b9">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:designator>YUDO</aixm:designator>
@@ -62,7 +62,7 @@
                     </sf:sampledFeature>
                     <sams:shape>
                         <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                        <gml:Point gml:id="point-5225-3201" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                        <gml:Point gml:id="uuid.b5e759b2-a6e4-4d0d-80cd-718ef62932dd" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                             <gml:pos>12.34 -12.34</gml:pos>
                         </gml:Point>
                     </sams:shape>
@@ -70,7 +70,7 @@
             </om:featureOfInterest>
             <!-- The result of the observation -->
             <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="or1" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="uuid.1b08e09f-708f-496e-bea9-0c29378dca77" cloudAndVisibilityOK="false">
                     <iwxxm:airTemperature uom="Cel">25.0</iwxxm:airTemperature>
                     <iwxxm:dewpointTemperature uom="Cel">22.0</iwxxm:dewpointTemperature>
                     <iwxxm:qnh uom="hPa">1008</iwxxm:qnh>
@@ -105,11 +105,11 @@
         </om:OM_Observation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="trend-fcst-1">
+        <om:OM_Observation gml:id="uuid.f159bbd9-bb16-4965-89c1-85719fe23587">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
             <!-- time at which the forecast conditions actually occur -->
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208221630Z-201208221700Z">
+                <gml:TimePeriod gml:id="uuid.ea6fb3d7-9a0f-4943-8b2c-ef0d3244edda">
                     <gml:beginPosition>2012-08-15T11:15:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-15T12:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -120,18 +120,18 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="trend-fcst-record-03839-201208221630Z-201208221700Z" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.1fcd6178-2764-4b35-826a-4d167d37c558" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
                 </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
             </om:result>
         </om:OM_Observation>
     </iwxxm:trendForecast>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="trend-fcst-2">
+        <om:OM_Observation gml:id="uuid.c5fae12c-6139-4da4-aa08-1674c11589fe">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
             <!-- time at which the forecast conditions actually occur -->
             <om:phenomenonTime>
-                <gml:TimeInstant gml:id="ti-44">
+                <gml:TimeInstant gml:id="uuid.9c559e62-d2f6-47df-b8cf-4b85b966d362">
                     <gml:timePosition>2012-08-15T12:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:phenomenonTime>
@@ -141,7 +141,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="trend-fcst-record-03839-201208221800Z-201208221900Z" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.d3071042-2012-48c7-9e4e-df49ffc8a3b9" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">8000</iwxxm:prevailingVisibility>
                     <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
                     <iwxxm:cloud nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -13,26 +13,26 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="taf-YUDO-201208160000Z"
+    gml:id="uuid.d6a85870-f32e-4ea8-8502-c7d9be7e0144"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
     <iwxxm:issueTime>
         <!-- Original TAF: 151800Z -->
-        <gml:TimeInstant gml:id="ti-201208151800Z">
+        <gml:TimeInstant gml:id="uuid.0c02ab83-22e8-4a66-b115-35544e7078f1">
             <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:issueTime>
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>
         <!-- Original TAF: 1600/1618 -->
-        <gml:TimePeriod gml:id="tp-201208160000-201208161800">
+        <gml:TimePeriod gml:id="uuid.ed5d465f-51fb-4ecc-834a-2ee26bb1196f">
             <gml:beginPosition>2012-08-16T00:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validTime>
     <iwxxm:baseForecast>
-        <om:OM_Observation gml:id="bf-1">
+        <om:OM_Observation gml:id="uuid.8c744255-74a6-41f1-80d6-b7fbccd29f73">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
             <!-- Base forecast phenomena occur throughout the valid period of the TAF -->
             <om:phenomenonTime xlink:href="#tp-201208160000-201208161800"/>
@@ -41,20 +41,20 @@
             <!-- base forecast conditions are valid throughout the TAF valid period -->
             <om:validTime xlink:href="#tp-201208160000-201208161800"/>
             <om:procedure>
-                <metce:Process gml:id="p-49-2-taf">
+                <metce:Process gml:id="uuid.c785c5df-cf62-49d3-9a57-54e1203bf11d">
                     <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 5 TECHNICAL SPECIFICATIONS RELATED TO FORECASTS</gml:description>
                 </metce:Process>
             </om:procedure>
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
             <om:featureOfInterest>
                 <!-- featureOfInterest type and shape MUST refer to a sampling Point -->
-                <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+                <sams:SF_SpatialSamplingFeature gml:id="uuid.9072432c-6c36-4859-9e23-f7666e35b4bc">
                     <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                     <sf:sampledFeature>
                       <!-- The aerodrome at which this forecast takes place -->
-                        <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+                        <aixm:AirportHeliport gml:id="uuid.a5a157ad-5b93-443d-a8e6-8324816ccb7e">
                             <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                                <aixm:AirportHeliportTimeSlice gml:id="uuid.9cf64bc2-0aca-452e-a330-9f6ce9f533e4">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                     <aixm:designator>YUDO</aixm:designator>
@@ -66,7 +66,7 @@
                     </sf:sampledFeature>
                     <sams:shape>
                         <!-- This is where the forecast took place, this is assumed to be representative of the sampledFeature -->
-                        <gml:Point gml:id="point-5225-3201" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                        <gml:Point gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                             <gml:pos>12.34 -12.34</gml:pos>
                         </gml:Point>
                     </sams:shape>
@@ -74,7 +74,7 @@
             </om:featureOfInterest>
             <om:result>
                 <!-- Original TAF: 13005MPS 9000 BKN020 -->
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="base-fcst-record" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.13048235-8f8a-4587-a6be-e8ce99f4525c" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">9000</iwxxm:prevailingVisibility>
                     <iwxxm:surfaceWind>
                         <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
@@ -83,7 +83,7 @@
                         </iwxxm:AerodromeSurfaceWindForecast>
                     </iwxxm:surfaceWind>
                     <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="acf1">
+                        <iwxxm:AerodromeCloudForecast gml:id="uuid.cbd88f13-e806-4ab9-857f-b82a66cc2854">
                             <iwxxm:layer>
                                 <iwxxm:CloudLayer>
                                     <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
@@ -98,10 +98,10 @@
     </iwxxm:baseForecast>
     <!-- Original TAF: BECMG 1606/1608 SCT015CB BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="cf-1">
+        <om:OM_Observation gml:id="uuid.bbda4671-37cd-4de0-8ab9-ff7845bcc853">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208160600-201208160608">
+                <gml:TimePeriod gml:id="uuid.921ff3f9-e89e-402e-acd1-82c8600f9929">
                     <gml:beginPosition>2012-08-16T06:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-16T08:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -114,9 +114,9 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="change-fcst-record-1" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.fe2635c8-3994-4423-b79f-123593fa2b55" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
                     <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="acf2">
+                        <iwxxm:AerodromeCloudForecast gml:id="uuid.235edc5d-213f-490b-8fdb-755032480849">
                             <iwxxm:layer>
                                 <iwxxm:CloudLayer>
                                     <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
@@ -138,10 +138,10 @@
     </iwxxm:changeForecast>
     <!-- Original TAF: TEMPO 1608/1612 17006G12MPS 1000 TSRA SCT010CB BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="bf-3">
+        <om:OM_Observation gml:id="uuid.c5cf385b-54f1-4b65-aee7-33714c40bbd0">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208160800-201208161200">
+                <gml:TimePeriod gml:id="uuid.5bdac885-79bf-4ebe-9693-cd0a4b2b91d0">
                     <gml:beginPosition>2012-08-16T08:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-16T12:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -154,7 +154,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="change-fcst-record-2" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.8985ba4e-f6f0-4dc2-8dd7-2cbf86a64056" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">1000</iwxxm:prevailingVisibility>
                     <!-- Original TAF: 17006G12MPS -->
                     <iwxxm:surfaceWind>
@@ -168,7 +168,7 @@
                     <iwxxm:weather xlink:href="http://codes.wmo.int/306/4678/TSRA"/>
                     <iwxxm:cloud>
                         <!-- Original TAF: SCT010CB BKN020 -->
-                        <iwxxm:AerodromeCloudForecast gml:id="acf3">
+                        <iwxxm:AerodromeCloudForecast gml:id="uuid.5d76e06c-220d-4491-83e8-439108891615">
                             <iwxxm:layer>
                                 <iwxxm:CloudLayer>
                                     <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
@@ -190,10 +190,10 @@
     </iwxxm:changeForecast>
     <!-- Original TAF: FM161230 15004MPS 9999 BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="bf-4">
+        <om:OM_Observation gml:id="uuid.859f8b5b-ae0c-4167-9cd5-dc62d3df9913">
             <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
             <om:phenomenonTime>
-                <gml:TimePeriod gml:id="tp-201208161230-201208170000">
+                <gml:TimePeriod gml:id="uuid.06f40788-ea21-471e-8c17-c0ef5b581c98">
                     <gml:beginPosition>2012-08-16T12:30:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-17T00:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -206,7 +206,7 @@
             <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
             <om:featureOfInterest xlink:href="#sampling-point-03839"/>
             <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="change-fcst-record-3" changeIndicator="FROM" cloudAndVisibilityOK="false">
+                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.aeadfb00-4cfa-46b5-af21-1e79e4b6b1b5" changeIndicator="FROM" cloudAndVisibilityOK="false">
                     <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
                     <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
                     <iwxxm:surfaceWind>
@@ -216,7 +216,7 @@
                         </iwxxm:AerodromeSurfaceWindForecast>
                     </iwxxm:surfaceWind>
                     <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="acf4">
+                        <iwxxm:AerodromeCloudForecast gml:id="uuid.ad9464f9-82de-49bd-8770-596b774591e5">
                             <iwxxm:layer>
                                 <iwxxm:CloudLayer>
                                     <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>

--- a/3.0.0RC1/examples/taf-A5-2.xml
+++ b/3.0.0RC1/examples/taf-A5-2.xml
@@ -10,19 +10,19 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
-    gml:id="taf-YUDO-20120816150000Z"
+    gml:id="uuid.dfbfe27c-3478-4efc-9800-124b90030e39"
     permissibleUsage="OPERATIONAL"
     status="CANCELLATION">
 
     <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="ti-20120816150000Z">
+        <gml:TimeInstant gml:id="uuid.2a142955-e0ef-4164-a550-ec80a3258150">
             <gml:timePosition>2012-08-16T15:00:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:issueTime>
 
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>
-        <gml:TimePeriod gml:id="tp-201208161500-201208170000">
+        <gml:TimePeriod gml:id="uuid.c700f1f7-5369-47fa-b934-914bbba4e17e">
             <gml:beginPosition>2012-08-16T15:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-17T00:00:00Z</gml:endPosition>
         </gml:TimePeriod>
@@ -30,9 +30,9 @@
 
     <!-- The Aerodrome of a previous report that is cancelled, amended or corrected -->
     <iwxxm:previousReportAerodrome>
-        <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+        <aixm:AirportHeliport gml:id="uuid.65730df9-a2fd-4815-9d3f-d6f6770bc6cf">
             <aixm:timeSlice>
-                <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.30a6076d-48ec-42df-bcd5-bf85220fe274">
                     <gml:validTime/>
                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                     <aixm:designator>YUDO</aixm:designator>
@@ -45,7 +45,7 @@
 
     <!-- The valid time period of a previous report that is cancelled, amended or corrected by this report -->
     <iwxxm:previousReportValidPeriod>
-        <gml:TimePeriod gml:id="tp-201208160600-201208170000">
+        <gml:TimePeriod gml:id="uuid.b171a7e2-7fdf-496c-ada8-6cbc6c606291">
             <gml:beginPosition>2012-08-16T00:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>

--- a/3.0.0RC1/examples/taf-NIL-collect.xml
+++ b/3.0.0RC1/examples/taf-NIL-collect.xml
@@ -20,43 +20,43 @@
                         http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
 			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
 			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
-    gml:id="uuid.efb207d7-e82a-4dbd-8a5c-9cbe4fad41b7">
+    gml:id="uuid.507b41d4-2656-4f93-a1d7-2d01bd8e4c50">
 
    <collect:meteorologicalInformation>
 
         <iwxxm:TAF 
-            gml:id="taf-YUDO-201208160000Z"
+            gml:id="uuid.ae3b123f-4fa1-447e-aa0e-5a950c8abff2"
             permissibleUsage="OPERATIONAL"
             status="MISSING">
         
             <iwxxm:issueTime>
-                <gml:TimeInstant gml:id="ti-201208221600Z">
+                <gml:TimeInstant gml:id="uuid.b28ba3dd-6544-4d7b-9a1f-342c63b458b5">
                     <gml:timePosition>2012-08-16T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </iwxxm:issueTime>
         
             <iwxxm:baseForecast>
-                <om:OM_Observation gml:id="bf">
+                <om:OM_Observation gml:id="uuid.314a496c-8cc4-419f-be94-f7ce233c3bfe">
                     <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
                     <!-- time at which the missing report was found to be missing -->
                     <om:phenomenonTime xlink:href="#ti-201208221600Z"/>
                     <!-- time at which the results are made available -->
                     <om:resultTime xlink:href="#ti-201208221600Z"/>
                     <om:procedure>
-                        <metce:Process gml:id="p-49-2-taf">
+                        <metce:Process gml:id="uuid.057c06bd-c3ff-483d-a32d-9727fd2c6314">
                             <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 5 TECHNICAL SPECIFICATIONS RELATED TO FORECASTS</gml:description>
                         </metce:Process>
                     </om:procedure>
                     <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
                     <om:featureOfInterest>
                         <!-- featureOfInterest type and shape must refer to a point -->
-                        <sams:SF_SpatialSamplingFeature gml:id="sampling-point-03839">
+                        <sams:SF_SpatialSamplingFeature gml:id="uuid.f91de288-35ec-4386-89bc-41dd84a9df69">
                             <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                             <sf:sampledFeature>
                                 <!-- The aerodrome at which this observation took place -->
-                                <aixm:AirportHeliport gml:id="aerodrome-YUDO">
+                                <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
                                     <aixm:timeSlice>
-                                        <aixm:AirportHeliportTimeSlice gml:id="aerodrome-YUDO-ts">
+                                        <aixm:AirportHeliportTimeSlice gml:id="uuid.64158cdb-c157-4df0-aba7-f2a385bb5935">
                                             <gml:validTime/>
                                             <aixm:interpretation>SNAPSHOT</aixm:interpretation>
                                             <aixm:designator>YUDO</aixm:designator>
@@ -68,7 +68,7 @@
                             </sf:sampledFeature>
                             <sams:shape>
                                 <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                                <gml:Point gml:id="point-5225-3201" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                <gml:Point gml:id="uuid.aedd0423-5540-49a0-954f-393b040450f4" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                                     <gml:pos>12.34 -12.34</gml:pos>
                                 </gml:Point>
                             </sams:shape>

--- a/3.0.0RC1/examples/taf-translation-failed.xml
+++ b/3.0.0RC1/examples/taf-translation-failed.xml
@@ -13,7 +13,7 @@
     http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
     http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
 
-    gml:id="taf-YUDO-201208160000Z"
+    gml:id="uuid.fa3ce106-f401-4670-ae50-cdf76bf68912"
     permissibleUsage="OPERATIONAL"
     translatedBulletinID="TTAAiiCCCYYGGgg"
     translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
@@ -25,14 +25,14 @@
 
     <iwxxm:issueTime>
         <!-- Original TAF: 151800Z -->
-        <gml:TimeInstant gml:id="ti-201208151800Z">
+        <gml:TimeInstant gml:id="uuid.1b9f7d3f-e09f-4d60-8fca-56b0de4dfebd">
             <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:issueTime>
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>
         <!-- Original TAF: 1600/1618 -->
-        <gml:TimePeriod gml:id="tp-201208160000-201208161800">
+        <gml:TimePeriod gml:id="uuid.e1352c79-926c-4493-9046-bba70cf8c578">
             <gml:beginPosition>2012-08-16T00:00:00Z</gml:beginPosition>
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>

--- a/3.0.0RC1/examples/tc-advisory-A2-2.xml
+++ b/3.0.0RC1/examples/tc-advisory-A2-2.xml
@@ -30,18 +30,18 @@ NXT MSG:                    20040925/2000Z
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
   http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="ID000" permissibleUsage="OPERATIONAL">
+  gml:id="uuid.217b27d6-fbc0-499b-b58e-4ee062c86cd4" permissibleUsage="OPERATIONAL">
 
   <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="ti-200409251600">
+      <gml:TimeInstant gml:id="uuid.d1858428-a96d-4825-aecd-07a929ab07d2">
           <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
       </gml:TimeInstant>
   </iwxxm:issueTime>
 
   <iwxxm:issuingTropicalCycloneAdvisoryCentre>
-    <aixm:Unit gml:id="tcac-YUFO">
+    <aixm:Unit gml:id="uuid.f4fdc1cc-6bfa-4f4c-9ea9-df5e2c2bd762">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uTTCACUnit">
+        <aixm:UnitTimeSlice gml:id="uuid.42cdad72-4180-4cfe-afe9-f743f87088ef">
           <gml:validTime/>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:type>OTHER:TCAC</aixm:type>
@@ -55,34 +55,34 @@ NXT MSG:                    20040925/2000Z
   <iwxxm:advisoryNumber>01</iwxxm:advisoryNumber>
 
   <iwxxm:observation>
-    <om:OM_Observation gml:id="tca-YUFO-01-obs">
+    <om:OM_Observation gml:id="uuid.720fbd91-a522-4872-a1d7-a512075dc1a6">
       <om:phenomenonTime>
-       <gml:TimeInstant gml:id="t1">
+       <gml:TimeInstant gml:id="uuid.023a036d-6945-492b-b9e5-30bf5df83179">
          <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
        </gml:TimeInstant>
       </om:phenomenonTime>
       <!-- time at which the results of the observation were made available -->
       <om:resultTime xlink:href="#ti-200409251600"/>
       <om:procedure>
-        <metce:Process gml:id="p-49-2">
+        <metce:Process gml:id="uuid.c09f7e9e-0ec6-4091-b0d8-3e500ed711af">
           <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 2 Tropical cyclone advisory information</gml:description>
         </metce:Process>
       </om:procedure>
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneObservedConditions"/>
       <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="obs1-feature">
+          <sams:SF_SpatialSamplingFeature gml:id="uuid.d0e29da6-c205-4421-beb7-a35440a2e088">
               <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
               <sam:sampledFeature xlink:href="#tcac-YUFO"/>
               <!-- TC centre -->
               <sams:shape>
-                  <gml:Point gml:id="obs1-point" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                  <gml:Point gml:id="uuid.8b4b12ed-461a-4716-8191-6cf41ad77471" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:pos>27.1 -73.1</gml:pos>
                   </gml:Point>
               </sams:shape>
           </sams:SF_SpatialSamplingFeature>
       </om:featureOfInterest>
       <om:result>
-        <iwxxm:TropicalCycloneObservedConditions gml:id="tcCond1">
+        <iwxxm:TropicalCycloneObservedConditions gml:id="uuid.78eddcd7-acfe-4649-b633-36189eaffc5d">
             <iwxxm:movement>MOVING</iwxxm:movement>
             <iwxxm:movementDirection uom="deg">315</iwxxm:movementDirection>
             <iwxxm:movementSpeed uom="km/h">20</iwxxm:movementSpeed>
@@ -95,9 +95,9 @@ NXT MSG:                    20040925/2000Z
 
   <!-- 6-hour forecast at 25/2200Z -->
   <iwxxm:forecast>
-    <om:OM_Observation gml:id="tca-YUFO-01-fcst-6hr">
+    <om:OM_Observation gml:id="uuid.1d8eae14-fca6-4247-9e13-dda703a2ee91">
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="ti-200409252200">
+        <gml:TimeInstant gml:id="uuid.6b115305-4200-4053-8ddb-0d036f907b69">
           <gml:timePosition>2004-09-25T22:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
@@ -106,19 +106,19 @@ NXT MSG:                    20040925/2000Z
       <om:procedure xlink:href="#p-49-2"/>
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
       <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="fcst1-feature">
+          <sams:SF_SpatialSamplingFeature gml:id="uuid.6b369dd3-1c28-422a-bd49-56378b138e5e">
               <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
               <sam:sampledFeature xlink:href="#tcac-YUFO"/>
               <!-- TC centre -->
               <sams:shape>
-                  <gml:Point gml:id="fcst1-point" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                  <gml:Point gml:id="uuid.e91ca02c-3625-4cdb-928c-d7979d45f2bc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                       <gml:pos>27.8 -73.83333</gml:pos>
                   </gml:Point>
               </sams:shape>
           </sams:SF_SpatialSamplingFeature>
       </om:featureOfInterest>
       <om:result>
-        <iwxxm:TropicalCycloneForecastConditions gml:id="tcCond3">
+        <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.75adc697-201c-485d-8356-1845ad46ae77">
             <iwxxm:maximumSurfaceWindSpeed uom="m/s">22</iwxxm:maximumSurfaceWindSpeed>
         </iwxxm:TropicalCycloneForecastConditions>
       </om:result>
@@ -127,9 +127,9 @@ NXT MSG:                    20040925/2000Z
 
   <!-- 12 hour forecast at 26/0400Z -->
   <iwxxm:forecast>
-      <om:OM_Observation gml:id="tca-YUFO-01-fcst-12hr">
+      <om:OM_Observation gml:id="uuid.598b9b20-c9d4-40ef-8a35-04fe4df8db5e">
           <om:phenomenonTime>
-              <gml:TimeInstant gml:id="ti-200409260400">
+              <gml:TimeInstant gml:id="uuid.b7991033-e147-4b77-8589-226c8eea39d4">
                   <gml:timePosition>2004-09-26T04:00:00Z</gml:timePosition>
               </gml:TimeInstant>
           </om:phenomenonTime>
@@ -138,19 +138,19 @@ NXT MSG:                    20040925/2000Z
           <om:procedure xlink:href="#p-49-2"/>
           <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
           <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="fcst2-feature">
+              <sams:SF_SpatialSamplingFeature gml:id="uuid.7f43de4b-5679-4355-a93f-d1931841f698">
                   <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                   <sam:sampledFeature xlink:href="#tcac-YUFO"/>
                   <!-- TC centre -->
                   <sams:shape>
-                      <gml:Point gml:id="fcst2-point" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                      <gml:Point gml:id="uuid.2e386620-5d45-4b7d-b171-4013f10f5ddc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                           <gml:pos>28.5 -74.5</gml:pos>
                       </gml:Point>
                   </sams:shape>
               </sams:SF_SpatialSamplingFeature>
           </om:featureOfInterest>
           <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="tcCond4">
+              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.13515111-4e81-4b60-85a7-eedc2b5f874f">
                   <iwxxm:maximumSurfaceWindSpeed uom="m/s">22</iwxxm:maximumSurfaceWindSpeed>
               </iwxxm:TropicalCycloneForecastConditions>
           </om:result>
@@ -159,9 +159,9 @@ NXT MSG:                    20040925/2000Z
 
   <!-- 18-hour forecast -->
   <iwxxm:forecast>
-      <om:OM_Observation gml:id="tca-YUFO-01-fcst-18hr">
+      <om:OM_Observation gml:id="uuid.50a39248-b6eb-4e9c-99d3-19e8d58b4d4e">
           <om:phenomenonTime>
-              <gml:TimeInstant gml:id="ti-200409261000">
+              <gml:TimeInstant gml:id="uuid.a747f059-2d07-4ba7-9317-c7e7eddc5adf">
                   <gml:timePosition>2004-09-26T10:00:00Z</gml:timePosition>
               </gml:TimeInstant>
           </om:phenomenonTime>
@@ -170,19 +170,19 @@ NXT MSG:                    20040925/2000Z
           <om:procedure xlink:href="#p-49-2"/>
           <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
           <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="fcst3-feature">
+              <sams:SF_SpatialSamplingFeature gml:id="uuid.e10eddd3-3157-44d7-a8a1-94d50342d31e">
                   <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                   <sam:sampledFeature xlink:href="#tcac-YUFO"/>
                   <!-- TC centre -->
                   <sams:shape>
-                      <gml:Point gml:id="fcst3-point" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                      <gml:Point gml:id="uuid.6dc4b702-ea53-4dc0-a261-ff8931bc84db" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                           <gml:pos>28.86667 -75.00</gml:pos>
                       </gml:Point>
                   </sams:shape>
               </sams:SF_SpatialSamplingFeature>
           </om:featureOfInterest>
           <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="tcCond5">
+              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.6c9b5a04-8be5-4a3e-8cb8-590e6a67d159">
                   <iwxxm:maximumSurfaceWindSpeed uom="m/s">21</iwxxm:maximumSurfaceWindSpeed>
               </iwxxm:TropicalCycloneForecastConditions>
           </om:result>
@@ -191,9 +191,9 @@ NXT MSG:                    20040925/2000Z
 
   <!-- 24-hour forecast -->
   <iwxxm:forecast>
-      <om:OM_Observation gml:id="tca-YUFO-01-fcst-24hr">
+      <om:OM_Observation gml:id="uuid.10953e18-32c7-4cee-837b-b26d0f19d97e">
           <om:phenomenonTime>
-              <gml:TimeInstant gml:id="ti-200409261600">
+              <gml:TimeInstant gml:id="uuid.3d372d30-0a48-4d4b-9f9b-a27bbd764890">
                   <gml:timePosition>2004-09-26T16:00:00Z</gml:timePosition>
               </gml:TimeInstant>
           </om:phenomenonTime>
@@ -202,19 +202,19 @@ NXT MSG:                    20040925/2000Z
           <om:procedure xlink:href="#p-49-2"/>
           <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
           <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="fcst4-feature">
+              <sams:SF_SpatialSamplingFeature gml:id="uuid.f06fae34-714f-48d2-8e5d-ec5b0ee3684e">
                   <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
                   <sam:sampledFeature xlink:href="#tcac-YUFO"/>
                   <!-- TC centre -->
                   <sams:shape>
-                      <gml:Point gml:id="fcst4-point" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                      <gml:Point gml:id="uuid.d26643a3-1106-4003-9978-558cdbef0e78" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                           <gml:pos>29.2 -75.5</gml:pos>
                       </gml:Point>
                   </sams:shape>
               </sams:SF_SpatialSamplingFeature>
           </om:featureOfInterest>
           <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="tcCond6">
+              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.708829ef-4ca3-4229-b57c-5f1c937c3b2b">
                   <iwxxm:maximumSurfaceWindSpeed uom="m/s">20</iwxxm:maximumSurfaceWindSpeed>
               </iwxxm:TropicalCycloneForecastConditions>
           </om:result>
@@ -222,7 +222,7 @@ NXT MSG:                    20040925/2000Z
   </iwxxm:forecast>
 
   <iwxxm:expectedNextAdvisoryTime>
-    <gml:TimeInstant gml:id="ti23">
+    <gml:TimeInstant gml:id="uuid.002b0056-d267-47b7-a9ef-4c7ca70aacd9">
       <gml:timePosition>2004-09-25T20:00:00Z</gml:timePosition>
     </gml:TimeInstant>
   </iwxxm:expectedNextAdvisoryTime>

--- a/3.0.0RC1/examples/tc-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/tc-advisory-translation-failed.xml
@@ -15,7 +15,7 @@ INVALID INVALID INVALID
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
   http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="ID000" permissibleUsage="OPERATIONAL"
+  gml:id="uuid.4a954e38-b132-4d3c-aaba-90dbd056d497" permissibleUsage="OPERATIONAL"
   translatedBulletinID="TTAAiiCCCYYGGgg"
   translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
   translationCentreDesignator="YUZZ"
@@ -29,24 +29,24 @@ INVALID INVALID INVALID
   INVALID INVALID INVALID">
 
   <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="ti-200409251600">
+      <gml:TimeInstant gml:id="uuid.3ea6b416-595b-4eb0-ad4c-3879fa5726d2">
           <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
       </gml:TimeInstant>
   </iwxxm:issueTime>
 
   <iwxxm:issuingTropicalCycloneAdvisoryCentre>
-    <aixm:Unit gml:id="tcac-YUFO">
+    <aixm:Unit gml:id="uuid.cf31d51c-7cac-4541-9183-5b295f56ae99">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uTTCACUnit">
+        <aixm:UnitTimeSlice gml:id="uuid.11e05972-5994-43f9-ab66-307b6d22fe89">
           <gml:validTime>
-            <gml:TimePeriod gml:id="vtTCACUnit">
+            <gml:TimePeriod gml:id="uuid.612e584d-774c-4408-a6a7-762180f240c6">
               <gml:beginPosition>2004-01-01T00:00:00Z</gml:beginPosition>
               <gml:endPosition indeterminatePosition="unknown"/>
             </gml:TimePeriod>
           </gml:validTime>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:featureLifetime>
-            <gml:TimePeriod gml:id="ltTCACUnit">
+            <gml:TimePeriod gml:id="uuid.7da41706-7660-4e0d-a26d-a00cc8b2ea87">
               <gml:beginPosition>2004-01-01T00:00:00Z</gml:beginPosition>
               <gml:endPosition indeterminatePosition="unknown"/>
             </gml:TimePeriod>

--- a/3.0.0RC1/examples/va-advisory-A2-1.xml
+++ b/3.0.0RC1/examples/va-advisory-A2-1.xml
@@ -36,18 +36,18 @@ NXT ADVISORY:               20080923/0730Z
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
   http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="ID000" permissibleUsage="OPERATIONAL">
+  gml:id="uuid.fb4861a8-0438-4f17-b8a7-efc13de58dec" permissibleUsage="OPERATIONAL">
 
   <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="ti-200809230130">
+      <gml:TimeInstant gml:id="uuid.efc2bc1b-fb52-4d66-ad22-73fcb857e8a3">
           <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
       </gml:TimeInstant>
   </iwxxm:issueTime>
 
   <iwxxm:issuingVolcanicAshAdvisoryCentre>
-    <aixm:Unit gml:id="vaac-TOKYO">
+    <aixm:Unit gml:id="uuid.456ad302-8380-45c9-b090-143bad6d4a0b">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uTTokyoVolcanicAshCentreUnit">
+        <aixm:UnitTimeSlice gml:id="uuid.9df94924-690e-4d9c-8025-8883c619b747">
           <gml:validTime/>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:name>TOKYO</aixm:name>
@@ -58,11 +58,11 @@ NXT ADVISORY:               20080923/0730Z
   </iwxxm:issuingVolcanicAshAdvisoryCentre>
 
   <iwxxm:volcano>
-    <metce:EruptingVolcano gml:id="karymsky">
+    <metce:EruptingVolcano gml:id="uuid.1b9ee023-c87d-4fa0-bf9b-bb1c7215286c">
       <gml:description>FL300 REPORTED</gml:description>
       <metce:name>KARYMSKY 1000-13</metce:name>
       <metce:position>
-        <gml:Point gml:id="karymskyPt" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+        <gml:Point gml:id="uuid.687c6e95-460a-4397-a602-ea8483acc3fc" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
             <gml:pos>54.03 159.27 1536</gml:pos>
         </gml:Point>
       </metce:position>
@@ -75,26 +75,26 @@ NXT ADVISORY:               20080923/0730Z
   <iwxxm:colourCode xlink:href="http://codes.wmo.int/49-2/AviationColourCode/RED"/>
 
   <iwxxm:analysis>
-    <om:OM_Observation gml:id="karymskyVAAObs">
+    <om:OM_Observation gml:id="uuid.f87d3aac-607c-4f10-8133-561d0fd7de8f">
       <om:phenomenonTime>
-       <gml:TimeInstant gml:id="t1">
+       <gml:TimeInstant gml:id="uuid.d894fd2c-890f-4c36-81b2-ae8576765929">
          <gml:timePosition>2008-09-23T01:00:00Z</gml:timePosition>
        </gml:TimeInstant>
       </om:phenomenonTime>
       <!-- time at which the results of the observation were made available -->
       <om:resultTime>
-        <gml:TimeInstant gml:id="ti-2">
+        <gml:TimeInstant gml:id="uuid.e7b1f336-e00f-4b06-b41a-76bf4c645bc1">
           <gml:timePosition>2008-09-23T00:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:resultTime>
       <om:procedure>
-        <metce:Process gml:id="p-49-2">
+        <metce:Process gml:id="uuid.9c55c6d7-9dac-47e4-8c91-5547714a8568">
           <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 2 Volcanic ash advisory information</gml:description>
         </metce:Process>
       </om:procedure>
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
       <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="ssf1">
+          <sams:SF_SpatialSamplingFeature gml:id="uuid.29743bd4-f637-41d3-81ce-30eae66d2931">
               <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
               <sam:sampledFeature xlink:href="#vaac-TOKYO"/>
               <!-- VAAC boundary - not typically reported -->
@@ -102,18 +102,18 @@ NXT ADVISORY:               20080923/0730Z
           </sams:SF_SpatialSamplingFeature>
       </om:featureOfInterest>
       <om:result>
-        <iwxxm:VolcanicAshConditions gml:id="vaCond1">
+        <iwxxm:VolcanicAshConditions gml:id="uuid.3182220e-b8ab-40f6-9be9-190b32b3d40e">
           <!-- FL250/300 N5400 E15930 N5400 E16100 N5300 E15945 MOV SE 20KT -->
           <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="vac1">
+            <iwxxm:VolcanicAshCloud gml:id="uuid.4dd54d1a-9a18-4065-b9e9-a0f25ced8f17">
                 <iwxxm:ashCloudExtent nilReason="unknown">
-                    <aixm:AirspaceVolume gml:id="vacav1">
+                    <aixm:AirspaceVolume gml:id="uuid.ca49fe24-81a5-4591-9d59-df21ea49d252">
                         <aixm:upperLimit uom="FL">300</aixm:upperLimit>
                         <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                         <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
                         <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                         <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="s1">
+                            <aixm:Surface gml:id="uuid.c81a85cc-61d9-4250-b9bb-fe4e9dcd3f29">
                                 <gml:patches>
                                     <gml:PolygonPatch>
                                         <gml:exterior>
@@ -133,15 +133,15 @@ NXT ADVISORY:               20080923/0730Z
           </iwxxm:ashCloud>
           <!-- SFC/FL200 N5130 E16130 N5130 E16230 N5230 E16230 N5230 E16130 MOV SE 15KT -->
           <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="vac2">
+            <iwxxm:VolcanicAshCloud gml:id="uuid.1f272bcf-ff35-45fe-9206-7963d574c752">
               <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="vacav2">
+                <aixm:AirspaceVolume gml:id="uuid.d8a40c1f-5026-47bc-b121-ba2cddbdae94">
                   <aixm:upperLimit uom="FL">200</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit>GND</aixm:lowerLimit>
                   <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="s2">
+                    <aixm:Surface gml:id="uuid.5d5747e4-da0c-4b2e-8a18-7c2d6c72d76c">
                       <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -166,9 +166,9 @@ NXT ADVISORY:               20080923/0730Z
 
   <!-- 23/0700Z -->
   <iwxxm:analysis>
-    <om:OM_Observation gml:id="karymskyVAA6hr">
+    <om:OM_Observation gml:id="uuid.9584191b-5246-40e1-b747-bfd136ffd578">
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="t2">
+        <gml:TimeInstant gml:id="uuid.7d89ec7f-6266-47d0-8f97-af0cd0905e9a">
           <gml:timePosition>2008-09-23T07:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
@@ -178,18 +178,18 @@ NXT ADVISORY:               20080923/0730Z
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
       <om:featureOfInterest xlink:href="#ssf1"/>
       <om:result>
-        <iwxxm:VolcanicAshConditions gml:id="vaCond3">
+        <iwxxm:VolcanicAshConditions gml:id="uuid.55a27198-f4e9-4a97-8e9d-0af6185f1b43">
           <!-- FL250/350 N5130 E16030 N5130 E16230 N5330 E16230 N5330 E16030 -->
           <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="vac3">
+            <iwxxm:VolcanicAshCloud gml:id="uuid.b8b23d9c-2794-406f-8b8a-6eb5cde393fb">
               <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="vacav3">
+                <aixm:AirspaceVolume gml:id="uuid.841fe208-2b26-47f9-a053-a7838a2c334f">
                   <aixm:upperLimit uom="FL">350</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
                   <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="s3">
+                    <aixm:Surface gml:id="uuid.ac2ae755-d6cc-480c-87ae-08bba04e3025">
                       <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -207,15 +207,15 @@ NXT ADVISORY:               20080923/0730Z
           </iwxxm:ashCloud>
           <!-- SFC/FL180 N4830 E16330 N4830 E16630 N5130 E16630 N5130 E16330 -->
           <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="vac4">
+            <iwxxm:VolcanicAshCloud gml:id="uuid.29dff823-5132-42ea-bcda-6e94a6b64983">
               <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="vacav4">
+                <aixm:AirspaceVolume gml:id="uuid.d4653c15-dd4f-418e-997a-d0983e7a56ae">
                   <aixm:upperLimit uom="FL">180</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit>GND</aixm:lowerLimit>
                   <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="s4">
+                    <aixm:Surface gml:id="uuid.4228e3dc-5384-41ce-a89b-ef2f5fe22470">
                       <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -238,9 +238,9 @@ NXT ADVISORY:               20080923/0730Z
 
   <!-- 23/1300Z -->
   <iwxxm:analysis>
-    <om:OM_Observation gml:id="karymskyVAA12hr">
+    <om:OM_Observation gml:id="uuid.cac25fb2-0765-4fc6-a7db-28f6b31fb389">
       <om:phenomenonTime>
-        <gml:TimeInstant gml:id="t3">
+        <gml:TimeInstant gml:id="uuid.2e92686b-2a88-44e3-a1ef-fed2cdf71d76">
           <gml:timePosition>2008-09-23T13:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </om:phenomenonTime>
@@ -250,18 +250,18 @@ NXT ADVISORY:               20080923/0730Z
       <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
       <om:featureOfInterest xlink:href="#ssf1"/>
       <om:result>
-        <iwxxm:VolcanicAshConditions gml:id="vaCond4">
+        <iwxxm:VolcanicAshConditions gml:id="uuid.6493c86f-6917-47f0-9749-19d656b1bd1f">
           <!-- SFC/FL270 N4830 E16130 Ð N4830 E16600 Ð N5300 E16600 Ð N5300 E16130  -->
           <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="vac6">
+            <iwxxm:VolcanicAshCloud gml:id="uuid.bcc01180-95c0-4ac1-8f13-53bbbfa430b7">
               <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="vacav6">
+                <aixm:AirspaceVolume gml:id="uuid.c35ee5c2-f8bf-43cb-ba9b-24f10fce6678">
                   <aixm:upperLimit uom="FL">270</aixm:upperLimit>
                   <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                   <aixm:lowerLimit>GND</aixm:lowerLimit>
                   <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
                   <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="s5">
+                    <aixm:Surface gml:id="uuid.216a05ac-926a-43aa-b5d2-ae740a6e7b37">
                       <gml:patches>
                         <gml:PolygonPatch>
                           <gml:exterior>
@@ -284,9 +284,9 @@ NXT ADVISORY:               20080923/0730Z
 
   <!-- 23/1900Z NO VA EXP -->
   <iwxxm:analysis>
-      <om:OM_Observation gml:id="karymskyVAA18hr">
+      <om:OM_Observation gml:id="uuid.54d4c566-606b-4ed5-babf-417a26e00f46">
           <om:phenomenonTime>
-              <gml:TimeInstant gml:id="t4">
+              <gml:TimeInstant gml:id="uuid.9b7632de-7591-4c3a-a876-99304e3d9d51">
                   <gml:timePosition>2008-09-23T19:00:00Z</gml:timePosition>
               </gml:TimeInstant>
           </om:phenomenonTime>
@@ -302,7 +302,7 @@ NXT ADVISORY:               20080923/0730Z
   <iwxxm:remarks>LATEST REP FM KVERT (0120Z) INDICATES ERUPTION HAS CEASED.  TWO DISPERSING VA CLD ARE EVIDENT ON SATELLITE IMAGERY</iwxxm:remarks>
 
   <iwxxm:nextAdvisoryEarliestTime>
-    <gml:TimeInstant gml:id="ti23">
+    <gml:TimeInstant gml:id="uuid.0480febc-1d6f-49bc-bca3-b54011e2f54f">
       <gml:timePosition>2008-09-23T07:30:00Z</gml:timePosition>
     </gml:TimeInstant>
   </iwxxm:nextAdvisoryEarliestTime>

--- a/3.0.0RC1/examples/va-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/va-advisory-translation-failed.xml
@@ -18,7 +18,7 @@ INVALID INVALID INVALID
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
   http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="ID000" permissibleUsage="OPERATIONAL"
+  gml:id="uuid.074f61f2-3775-4e8b-b60c-17b238d60566" permissibleUsage="OPERATIONAL"
   translatedBulletinID="TTAAiiCCCYYGGgg"
   translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
   translationCentreDesignator="YUZZ"
@@ -34,24 +34,24 @@ INVALID INVALID INVALID
   INVALID INVALID INVALID">
 
   <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="ti-200809230130">
+      <gml:TimeInstant gml:id="uuid.cb1e8cbb-91c7-4777-b143-ae681d02b09d">
           <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
       </gml:TimeInstant>
   </iwxxm:issueTime>
 
   <iwxxm:issuingVolcanicAshAdvisoryCentre>
-    <aixm:Unit gml:id="vaac-TOKYO">
+    <aixm:Unit gml:id="uuid.b02269db-1e76-4534-8296-30f950fb3b70">
       <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uTTokyoVolcanicAshCentreUnit">
+        <aixm:UnitTimeSlice gml:id="uuid.8c408057-3105-46c2-aec8-31d1611eed39">
           <gml:validTime>
-            <gml:TimePeriod gml:id="vtTokyoVolcanicAshCentreUnit">
+            <gml:TimePeriod gml:id="uuid.c958a171-97a6-4d36-92b5-2979cc97a10d">
               <gml:beginPosition>2008-01-01T00:00:00Z</gml:beginPosition>
               <gml:endPosition indeterminatePosition="unknown"/>
             </gml:TimePeriod>
           </gml:validTime>
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:featureLifetime>
-            <gml:TimePeriod gml:id="ltTokyoVolcanicAshCentreUnit">
+            <gml:TimePeriod gml:id="uuid.071b5cb7-540b-4630-ac0e-3d6100b6337b">
               <gml:beginPosition>2008-01-01T00:00:00Z</gml:beginPosition>
               <gml:endPosition indeterminatePosition="unknown"/>
             </gml:TimePeriod>
@@ -64,11 +64,11 @@ INVALID INVALID INVALID
   </iwxxm:issuingVolcanicAshAdvisoryCentre>
 
   <iwxxm:volcano>
-    <metce:EruptingVolcano gml:id="karymsky">
+    <metce:EruptingVolcano gml:id="uuid.a0853f49-b98d-41cd-87be-a3ffa6ffd352">
       <gml:description>FL300 REPORTED</gml:description>
       <metce:name>KARYMSKY 1000-13</metce:name>
       <metce:position>
-        <gml:Point gml:id="karymskyPt" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+        <gml:Point gml:id="uuid.4a863495-6f14-4921-9aa8-0162764772ed" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
             <gml:pos>54.03 159.27 1536</gml:pos>
         </gml:Point>
       </metce:position>

--- a/3.0.0RC1/rule/iwxxm-collect-codelists.sch
+++ b/3.0.0RC1/rule/iwxxm-collect-codelists.sch
@@ -565,6 +565,11 @@
          <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
       </sch:rule>
    </sch:pattern>
+   <sch:pattern id="COMMON.Report5">
+     <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+       <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
+     </sch:rule>
+   </sch:pattern>
    <sch:pattern id="COMMON.Report2">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="(if(@permissibleUsage eq 'OPERATIONAL') then( not( exists(@permissibleUsageReason))) else(true()))">COMMON.Report2: Operational reports should not include a permissibleUsageReason</sch:assert>

--- a/3.0.0RC1/rule/iwxxm-collect.sch
+++ b/3.0.0RC1/rule/iwxxm-collect.sch
@@ -565,6 +565,11 @@
          <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
       </sch:rule>
    </sch:pattern>
+   <sch:pattern id="COMMON.Report5">
+     <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+       <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
+     </sch:rule>
+   </sch:pattern>
    <sch:pattern id="COMMON.Report2">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="(if(@permissibleUsage eq 'OPERATIONAL') then( not( exists(@permissibleUsageReason))) else(true()))">COMMON.Report2: Operational reports should not include a permissibleUsageReason</sch:assert>

--- a/3.0.0RC1/rule/iwxxm.sch
+++ b/3.0.0RC1/rule/iwxxm.sch
@@ -559,7 +559,12 @@
          <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
       </sch:rule>
    </sch:pattern>
-   <sch:pattern id="COMMON.Report2">
+  <sch:pattern id="COMMON.Report5">
+    <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+      <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="COMMON.Report2">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="(if(@permissibleUsage eq 'OPERATIONAL') then( not( exists(@permissibleUsageReason))) else(true()))">COMMON.Report2: Operational reports should not include a permissibleUsageReason</sch:assert>
       </sch:rule>


### PR DESCRIPTION
All examples now have every gml:id set to a UUIDv4, and the Schematron files were updated to ensure that all gml:ids under the report types (METAR, TAF, etc.) are UUIDs.  Fixes #31 and fixes #33.

Note that another alternative would be to leave out the Schematron portions so that it is a recommended practice but not a mandatory practice