### PR TITLE
Simplified a representative set of examples for removing O&M

### DIFF
--- a/3.0.0RC1/ReleaseNotes-IWXXM.txt
+++ b/3.0.0RC1/ReleaseNotes-IWXXM.txt
@@ -1,4 +1,11 @@
 ====================================
+3.0.0RC1 - ??
+====================================
+* Restructure the model to remove O&M
+- Remove Schematron rule METAR_SPECI.MATFR5 as it has become redundant
+
+
+====================================
 2.1.1 - November 2017
 ====================================
 - Removed Schematron rules SIGMET.SEC3, SIGMET.SEC4, AIRMET.AEC9 and AIRMET.AEC10 to fix vertical extend encoding for 

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
@@ -19,9 +19,13 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:AIRMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which meteorological phenomena occur</documentation>
+						</annotation>
+					</element>
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element AIRMETEvolvingConditionCollection</documentation>
 						</annotation>
@@ -53,6 +57,11 @@ The AIRMET report class represents the base AIRMET types that may be reported su
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
+					<element name="issueTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which this report was issued</documentation>
+						</annotation>
+					</element>
 					<element name="issuingAirTrafficServicesUnit" type="iwxxm:UnitPropertyType">
 						<annotation>
 							<documentation>The ATS unit serving the FIR or CTA to which the AIRMET refers.  ICAO Annex 3 / WMO No. 49-2: A6-1: "Location indicator of FIR/CTA"</documentation>
@@ -63,13 +72,16 @@ The AIRMET report class represents the base AIRMET types that may be reported su
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
-					<element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
+					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType">
+						<annotation>
+							<documentation>The ATS region (FIR, UIR, CTA, or FIR/UIR)</documentation>
+						</annotation>
+					</element>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>
 						</annotation>
 					</element>
-					<element name="issueTime" type="gml:TimeInstantPropertyType"/>
 					<element name="validPeriod" type="gml:TimePeriodPropertyType">
 						<annotation>
 							<documentation>The valid period for the entire report, including all observations and forecast conditions.  Each observation/forecast phenomenon includes its own period of validity for described meteorological conditions, which is represented as the O&amp;M Observation validTime.</documentation>
@@ -94,12 +106,26 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:AIRMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>AIRMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  AIRMETs may include a single set of observed and/or forecast conditions at a particular time, which is represented  as a single analysis with a single AIRMETEvolvingConditionCollection as its result.</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:AIRMETEvolvingConditionCollection"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element AIRMET</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element AIRMET</documentation>
 						</annotation>
@@ -219,7 +245,7 @@ Appendix 6 Section 2.1</documentation>
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element AIRMETEvolvingCondition</documentation>
 						</annotation>

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>AIRMET reporting constructs as defined in ICAO Annex 3 / WMO No. 49-2.
@@ -20,6 +19,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:AIRMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
@@ -63,11 +63,14 @@ The AIRMET report class represents the base AIRMET types that may be reported su
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
+					<element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
+					<element name="flightInformationRegionBoundary" type="gml:GeometryPropertyType" minOccurs="0"/>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>
 						</annotation>
 					</element>
+					<element name="issueTime" type="gml:TimeInstantPropertyType"/>
 					<element name="validPeriod" type="gml:TimePeriodPropertyType">
 						<annotation>
 							<documentation>The valid period for the entire report, including all observations and forecast conditions.  Each observation/forecast phenomenon includes its own period of validity for described meteorological conditions, which is represented as the O&amp;M Observation validTime.</documentation>
@@ -92,7 +95,7 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:AIRMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>AIRMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  AIRMETs may include a single set of observed and/or forecast conditions at a particular time, which is represented  as a single analysis with a single AIRMETEvolvingConditionCollection as its result.</documentation>
 						</annotation>

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -101,12 +101,12 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous AIRMET that is cancelled by this AIRMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonType">
+					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonPropertyType">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:AIRMETEvolvingConditionCollectionType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:AIRMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>AIRMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  AIRMETs may include a single set of observed and/or forecast conditions at a particular time, which is represented  as a single analysis with a single AIRMETEvolvingConditionCollection as its result.</documentation>
 						</annotation>
@@ -143,7 +143,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The expected direction of movement of a meteorological condition. When no movement is expected, this is a http://www.opengis.net/def/nil/OGC/0/inapplicable nilReason and the speedOfMotion will be 0.  Direction of motion to shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
 						</annotation>
@@ -213,7 +213,7 @@ Appendix 6 Section 2.1</documentation>
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="surfaceVisibilityCause" type="iwxxm:WeatherCausingVisibilityReductionType" minOccurs="0" maxOccurs="unbounded">
+					<element name="surfaceVisibilityCause" type="iwxxm:WeatherCausingVisibilityReductionPropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The weather condition(s) causing reduced visibility.</documentation>
 						</annotation>
@@ -237,7 +237,7 @@ Appendix 6 Section 2.1</documentation>
 						</annotation>
 					</element>
 				</sequence>
-				<attribute name="intensityChange" type="iwxxm:AIRMETExpectedIntensityChangeType">
+				<attribute name="intensityChange" type="iwxxm:AIRMETExpectedIntensityChangePropertyType">
 					<annotation>
 						<documentation>The expected change in intensity for the reported meteorological condition (e.g., intensifying, weakening, or no change) determined at the time of AIRMET analysis based on the current state of the meteorological condition</documentation>
 					</annotation>

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -106,24 +106,10 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:AIRMETEvolvingConditionCollectionType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>AIRMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  AIRMETs may include a single set of observed and/or forecast conditions at a particular time, which is represented  as a single analysis with a single AIRMETEvolvingConditionCollection as its result.</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:AIRMETEvolvingConditionCollection"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element AIRMET</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -19,12 +19,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="member" type="iwxxm:AIRMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
-					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
-						<annotation>
-							<documentation>The time at which meteorological phenomena occur</documentation>
-						</annotation>
-					</element>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
+				    <element name="member" type="iwxxm:AIRMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element AIRMETEvolvingConditionCollection</documentation>
@@ -101,7 +101,7 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous AIRMET that is cancelled by this AIRMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonPropertyType">
+					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonType">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>
@@ -143,7 +143,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The expected direction of movement of a meteorological condition. When no movement is expected, this is a http://www.opengis.net/def/nil/OGC/0/inapplicable nilReason and the speedOfMotion will be 0.  Direction of motion to shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
 						</annotation>
@@ -213,7 +213,7 @@ Appendix 6 Section 2.1</documentation>
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="surfaceVisibilityCause" type="iwxxm:WeatherCausingVisibilityReductionPropertyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="surfaceVisibilityCause" type="iwxxm:WeatherCausingVisibilityReductionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The weather condition(s) causing reduced visibility.</documentation>
 						</annotation>
@@ -237,7 +237,7 @@ Appendix 6 Section 2.1</documentation>
 						</annotation>
 					</element>
 				</sequence>
-				<attribute name="intensityChange" type="iwxxm:AIRMETExpectedIntensityChangePropertyType">
+				<attribute name="intensityChange" type="iwxxm:AIRMETExpectedIntensityChangeType">
 					<annotation>
 						<documentation>The expected change in intensity for the reported meteorological condition (e.g., intensifying, weakening, or no change) determined at the time of AIRMET analysis based on the current state of the meteorological condition</documentation>
 					</annotation>

--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -64,7 +64,6 @@ The AIRMET report class represents the base AIRMET types that may be reported su
 						</annotation>
 					</element>
 					<element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
-					<element name="flightInformationRegionBoundary" type="gml:GeometryPropertyType" minOccurs="0"/>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>

--- a/3.0.0RC1/common.xsd
+++ b/3.0.0RC1/common.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
-	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
+    <include schemaLocation="measures.xsd"></include>
+    <import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>Common constructs used across multiple packages.  This package includes constructs closely related to the aviation weather domain.
@@ -82,7 +83,7 @@ A single vertical visibility may be reported, but cannot be reported with cloud 
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-					<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The vertical visibility.  Vertical visibility is defined as the vertical visual range into an obscuring medium.
 
@@ -216,12 +217,12 @@ When no operator is reported, wind gust speed is an exact value with identical s
 	</element>
 	<complexType name="CloudLayerType">
 		<sequence>
-			<element nillable="true" name="amount" type="iwxxm:CloudAmountReportedAtAerodromePropertyType">
+			<element nillable="true" name="amount" type="iwxxm:CloudAmountReportedAtAerodromeType">
 				<annotation>
 					<documentation>The observed cloud amount</documentation>
 				</annotation>
 			</element>
-			<element nillable="true" name="base" type="iwxxm:DistanceWithNilReasonPropertyType">
+			<element nillable="true" name="base" type="iwxxm:DistanceWithNilReasonType">
 				<annotation>
 					<documentation>For a given cloud or cloud layer, height of the lowest level in the atmosphere at which the air contains a perceptible quantity of cloud particles.
 
@@ -231,7 +232,7 @@ Measured cloud bases shall be reported in meters ("m") or feet ("[ft_i]").</docu
 					</appinfo>
 				</annotation>
 			</element>
-			<element nillable="true" name="cloudType" type="iwxxm:SigConvectiveCloudTypePropertyType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="cloudType" type="iwxxm:SigConvectiveCloudTypeType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The observed significant cloud types: cumulonimbus or towering cumulus</documentation>
 				</annotation>
@@ -344,6 +345,15 @@ For example, the "above" operator in conjunction with the reported quantity 10.6
 			<any processContents="strict"/>
 		</sequence>
 	</complexType>
+    <complexType name="TimeObjectPropertyType">
+        <annotation>
+            <documentation>This property type is not provided directly by GML</documentation>
+        </annotation>
+        <sequence minOccurs="0">
+            <element ref="gml:AbstractTimeObject"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
 	<simpleType name="TimeIndicatorType">
 		<annotation>
 			<documentation>Whether the information is observed and expected to continue, or forecast</documentation>

--- a/3.0.0RC1/common.xsd
+++ b/3.0.0RC1/common.xsd
@@ -339,6 +339,15 @@ For example, the "above" operator in conjunction with the reported quantity 10.6
 		<attributeGroup ref="gml:AssociationAttributeGroup"/>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
 	</complexType>
+    <complexType name="TimeObjectPropertyType">
+        <annotation>
+            <documentation>This property type is not provided directly by GML</documentation>
+        </annotation>
+        <sequence minOccurs="0">
+            <element ref="gml:AbstractTimeObject"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
 	<simpleType name="TimeIndicatorType">
 		<annotation>
 			<documentation>Whether the information is observed and expected to continue, or forecast</documentation>

--- a/3.0.0RC1/common.xsd
+++ b/3.0.0RC1/common.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -101,7 +101,7 @@ Vertical visibility shall be reported either in meters ("m") or feet ("[ft_i]").
 							</complexContent>
 						</complexType>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element AerodromeCloudForecast</documentation>
 						</annotation>
@@ -196,7 +196,7 @@ Wind gusts shall be provided in either two units of measures: "m/s" or "[kn_i]" 
 When no operator is reported, wind gust speed is an exact value with identical semantics to other measured quantities.</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeSurfaceWindTrendForecast</documentation>
 				</annotation>
@@ -236,7 +236,7 @@ Measured cloud bases shall be reported in meters ("m") or feet ("[ft_i]").</docu
 					<documentation>The observed significant cloud types: cumulonimbus or towering cumulus</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element CloudLayer</documentation>
 				</annotation>
@@ -339,15 +339,11 @@ For example, the "above" operator in conjunction with the reported quantity 10.6
 		<attributeGroup ref="gml:AssociationAttributeGroup"/>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
 	</complexType>
-    <complexType name="TimeObjectPropertyType">
-        <annotation>
-            <documentation>This property type is not provided directly by GML</documentation>
-        </annotation>
-        <sequence minOccurs="0">
-            <element ref="gml:AbstractTimeObject"/>
-        </sequence>
-        <attributeGroup ref="gml:AssociationAttributeGroup"/>
-    </complexType>
+	<complexType name="ExtensionType">
+		<sequence>
+			<any processContents="strict"/>
+		</sequence>
+	</complexType>
 	<simpleType name="TimeIndicatorType">
 		<annotation>
 			<documentation>Whether the information is observed and expected to continue, or forecast</documentation>

--- a/3.0.0RC1/common.xsd
+++ b/3.0.0RC1/common.xsd
@@ -82,7 +82,7 @@ A single vertical visibility may be reported, but cannot be reported with cloud 
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-					<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The vertical visibility.  Vertical visibility is defined as the vertical visual range into an obscuring medium.
 
@@ -216,12 +216,12 @@ When no operator is reported, wind gust speed is an exact value with identical s
 	</element>
 	<complexType name="CloudLayerType">
 		<sequence>
-			<element nillable="true" name="amount" type="iwxxm:CloudAmountReportedAtAerodromeType">
+			<element nillable="true" name="amount" type="iwxxm:CloudAmountReportedAtAerodromePropertyType">
 				<annotation>
 					<documentation>The observed cloud amount</documentation>
 				</annotation>
 			</element>
-			<element nillable="true" name="base" type="iwxxm:DistanceWithNilReasonType">
+			<element nillable="true" name="base" type="iwxxm:DistanceWithNilReasonPropertyType">
 				<annotation>
 					<documentation>For a given cloud or cloud layer, height of the lowest level in the atmosphere at which the air contains a perceptible quantity of cloud particles.
 
@@ -231,7 +231,7 @@ Measured cloud bases shall be reported in meters ("m") or feet ("[ft_i]").</docu
 					</appinfo>
 				</annotation>
 			</element>
-			<element nillable="true" name="cloudType" type="iwxxm:SigConvectiveCloudTypeType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="cloudType" type="iwxxm:SigConvectiveCloudTypePropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The observed significant cloud types: cumulonimbus or towering cumulus</documentation>
 				</annotation>

--- a/3.0.0RC1/examples/airmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/airmet-A6-1a-TS.xml
@@ -8,43 +8,60 @@
 <iwxxm:AIRMET xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" 
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd 
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd 
-    http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     
     permissibleUsage="OPERATIONAL"
     gml:id="uuid.69a2497b-193c-47bf-a6bd-1cc71acbc8e5" status="NORMAL">
     
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.1b54b36f-bc16-4111-abb6-05ff6aad744b">
-          <aixm:timeSlice>
-              <aixm:UnitTimeSlice gml:id="uuid.91cf4ebe-8687-432f-a1e1-aaf7ebc053b2">
-              <gml:validTime/>
-              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-              <aixm:name>YUDD FIC</aixm:name>
-              <aixm:type>FIC</aixm:type>
-              <aixm:designator>YUDD</aixm:designator>
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.91cf4ebe-8687-432f-a1e1-aaf7ebc053b2">
+                <gml:validTime/>
+                <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                <aixm:name>YUDD FIC</aixm:name>
+                <aixm:type>FIC</aixm:type>
+                <aixm:designator>YUDD</aixm:designator>
             </aixm:UnitTimeSlice>
-          </aixm:timeSlice>
+            </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
     <iwxxm:originatingMeteorologicalWatchOffice>
-      <aixm:Unit gml:id="uuid.30437923-6a83-4bc7-a07e-66e7419e50df">
-          <aixm:timeSlice>
-            <aixm:UnitTimeSlice gml:id="uuid.f8eb9604-6ddb-4553-9d9e-84548fb7af42">
-              <gml:validTime/>
-              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-              <aixm:name>YUDD MWO</aixm:name>
-              <aixm:type>MWO</aixm:type>
-              <aixm:designator>YUDD</aixm:designator>
-            </aixm:UnitTimeSlice>
+        <aixm:Unit gml:id="uuid.30437923-6a83-4bc7-a07e-66e7419e50df">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.f8eb9604-6ddb-4553-9d9e-84548fb7af42">
+                  <gml:validTime/>
+                  <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                  <aixm:name>YUDD MWO</aixm:name>
+                  <aixm:type>MWO</aixm:type>
+                  <aixm:designator>YUDD</aixm:designator>
+                </aixm:UnitTimeSlice>
           </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
-    
+
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.09f5436c-cf2c-40ca-add5-c95a8f6875f9">
+              <aixm:timeSlice>
+                    <aixm:AirspaceTimeSlice gml:id="uuid.c62fe63e-792d-49e6-9f09-b6c2940d1591">
+                          <gml:validTime/>
+                          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                          <aixm:type>FIR</aixm:type>
+                          <aixm:designator>YUCC</aixm:designator>
+                          <aixm:name>AMSWELL FIR</aixm:name>
+                    </aixm:AirspaceTimeSlice>
+              </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
+
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
+
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.6ffb87f7-6eef-4bae-b4f2-016e2951d7dd">
+            <gml:timePosition>2014-05-15T15:20:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
     
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.74b125c2-a4ad-4434-b3c0-f650eb57ce93">
@@ -57,78 +74,36 @@
     
     <!-- OBS N OF S50 TOP ABV FL100 STNR WKN -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="uuid.31e77f13-c64e-4904-ad50-5886d9c99747">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/AIRMETEvolvingConditionCollectionAnalysis"/>
-            <!-- time of observed conditions -->
-            <om:phenomenonTime nilReason="missing"/>
-            
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.6ffb87f7-6eef-4bae-b4f2-016e2951d7dd">
-                    <gml:timePosition>2014-05-15T15:20:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <!-- The valid period for this observation is the period of the entire AIRMET -->
-            <om:validTime xlink:href="#tp1"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.be73c6d1-a164-45ec-951e-e8b665397c0b">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO AIRMET INFORMATION</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/AIRMETEvolvingConditionCollectionAnalysis"/>
-            <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.4be2f92a-f3f9-42a3-9237-f034170647a4">
-                    <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-                    <sam:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.09f5436c-cf2c-40ca-add5-c95a8f6875f9">
-                          <aixm:timeSlice>
-                            <aixm:AirspaceTimeSlice gml:id="uuid.c62fe63e-792d-49e6-9f09-b6c2940d1591">
-                              <gml:validTime/>
-                              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                              <aixm:type>FIR</aixm:type>
-                              <aixm:designator>YUCC</aixm:designator>
-                              <aixm:name>AMSWELL FIR</aixm:name>
-                            </aixm:AirspaceTimeSlice>
-                          </aixm:timeSlice>
-                        </aixm:Airspace>
-                    </sam:sampledFeature>
-                    <!-- FIR boundary - not typically reported -->
-                    <sams:shape nilReason="withheld"/>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <!-- N OF S50 TOP ABV FL100 STNR WKN -->
-                <iwxxm:AIRMETEvolvingConditionCollection gml:id="uuid.d61fb5e7-b55e-462e-9e2b-0cb8dc366064" timeIndicator="OBSERVATION">
-                  <iwxxm:member>
-                    <iwxxm:AIRMETEvolvingCondition gml:id="uuid.deeb1ae5-0094-4ec8-af92-aa7b3f156a3f" intensityChange="WEAKEN">
-                      <iwxxm:directionOfMotion xsi:nil="true" uom="N/A" nilReason="inapplicable"/>
-                      <iwxxm:geometry>
+        <!-- N OF S50 TOP ABV FL100 STNR WKN -->
+        <iwxxm:AIRMETEvolvingConditionCollection gml:id="uuid.d61fb5e7-b55e-462e-9e2b-0cb8dc366064" timeIndicator="OBSERVATION">
+            <iwxxm:phenomenonTime nilReason="missing"/>
+            <iwxxm:member>
+                <iwxxm:AIRMETEvolvingCondition gml:id="uuid.deeb1ae5-0094-4ec8-af92-aa7b3f156a3f" intensityChange="WEAKEN">
+                    <iwxxm:directionOfMotion xsi:nil="true" uom="N/A" nilReason="inapplicable"/>
+                    <iwxxm:geometry>
                         <aixm:AirspaceVolume gml:id="uuid.8ed71782-7c63-4ca5-9ed6-a31b788f64af">
-                          <aixm:lowerLimit uom="FL">100</aixm:lowerLimit>
-                          <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
-                          <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="uuid.626c2d10-d5ba-427e-a0c8-98949dd20a69" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
-                                <gml:PolygonPatch>
-                                  <gml:exterior>
-                                    <gml:LinearRing>
-                                      <!-- bounding polygon N of S50 clipped to edge of FIR -->
-                                      <gml:posList>-50.0 50.0 -50.0 70.0 -40.0 70.0 -40.0 50.0 -50.0 50.0</gml:posList>
-                                    </gml:LinearRing>
-                                  </gml:exterior>
-                                </gml:PolygonPatch>
-                              </gml:polygonPatches>
-                            </aixm:Surface>
-                          </aixm:horizontalProjection>
+                            <aixm:lowerLimit uom="FL">100</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.626c2d10-d5ba-427e-a0c8-98949dd20a69" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <!-- bounding polygon N of S50 clipped to edge of FIR -->
+                                                    <gml:posList>-50.0 50.0 -50.0 70.0 -40.0 70.0 -40.0 50.0 -50.0 50.0</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
-                      </iwxxm:geometry>
-                      <iwxxm:geometryUpperLimitOperator>ABOVE</iwxxm:geometryUpperLimitOperator>
-                      <iwxxm:speedOfMotion uom="[kn_i]">0</iwxxm:speedOfMotion>
-                    </iwxxm:AIRMETEvolvingCondition>
-                  </iwxxm:member>
-                </iwxxm:AIRMETEvolvingConditionCollection>
-            </om:result>
-        </om:OM_Observation>
+                    </iwxxm:geometry>
+                    <iwxxm:geometryUpperLimitOperator>ABOVE</iwxxm:geometryUpperLimitOperator>
+                    <iwxxm:speedOfMotion uom="[kn_i]">0</iwxxm:speedOfMotion>
+                </iwxxm:AIRMETEvolvingCondition>
+            </iwxxm:member>
+        </iwxxm:AIRMETEvolvingConditionCollection>
     </iwxxm:analysis>
 </iwxxm:AIRMET>

--- a/3.0.0RC1/examples/airmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/airmet-A6-1a-TS.xml
@@ -50,6 +50,7 @@
                           <aixm:type>FIR</aixm:type>
                           <aixm:designator>YUCC</aixm:designator>
                           <aixm:name>AMSWELL FIR</aixm:name>
+                        <!-- FIR boundary can be reported in an aixm:geometryComponent -->
                     </aixm:AirspaceTimeSlice>
               </aixm:timeSlice>
         </aixm:Airspace>

--- a/3.0.0RC1/examples/airmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/airmet-A6-1a-TS.xml
@@ -14,6 +14,12 @@
     permissibleUsage="OPERATIONAL"
     gml:id="uuid.69a2497b-193c-47bf-a6bd-1cc71acbc8e5" status="NORMAL">
     
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.6ffb87f7-6eef-4bae-b4f2-016e2951d7dd">
+            <gml:timePosition>2014-05-15T15:20:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.1b54b36f-bc16-4111-abb6-05ff6aad744b">
             <aixm:timeSlice>
@@ -41,7 +47,7 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.09f5436c-cf2c-40ca-add5-c95a8f6875f9">
               <aixm:timeSlice>
                     <aixm:AirspaceTimeSlice gml:id="uuid.c62fe63e-792d-49e6-9f09-b6c2940d1591">
@@ -54,16 +60,10 @@
                     </aixm:AirspaceTimeSlice>
               </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
 
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
 
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.6ffb87f7-6eef-4bae-b4f2-016e2951d7dd">
-            <gml:timePosition>2014-05-15T15:20:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
-    
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.74b125c2-a4ad-4434-b3c0-f650eb57ce93">
             <gml:beginPosition>2014-05-15T15:20:00</gml:beginPosition>

--- a/3.0.0RC1/examples/airmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/airmet-A6-1a-TS.xml
@@ -6,10 +6,10 @@
     YUDD SHANLON FIR ISOL TS 
     OBS N OF S50 TOP ABV FL100 STNR WKN -->
 <iwxxm:AIRMET xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+    xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     
     permissibleUsage="OPERATIONAL"
     gml:id="uuid.69a2497b-193c-47bf-a6bd-1cc71acbc8e5" status="NORMAL">

--- a/3.0.0RC1/examples/airmet-translation-failed.xml
+++ b/3.0.0RC1/examples/airmet-translation-failed.xml
@@ -24,6 +24,12 @@
     OBS N OF S50 TOP ABV FL100 STNR WKN"
     status="NORMAL">
 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
+            <gml:timePosition>2014-05-10T15:00:00</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.500c55b8-3d10-40cb-8243-159b05ca0e98">
             <aixm:timeSlice>
@@ -51,7 +57,7 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
@@ -63,15 +69,9 @@
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
 
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
-
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
-            <gml:timePosition>2014-05-10T15:00:00</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
 
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.b1c4f44c-f702-43a8-95c7-79c5823d9dd0">

--- a/3.0.0RC1/examples/airmet-translation-failed.xml
+++ b/3.0.0RC1/examples/airmet-translation-failed.xml
@@ -7,10 +7,10 @@
     YUDD SHANLON FIR INVALID TS
     OBS N OF S50 TOP ABV FL100 STNR WKN -->
 <iwxxm:AIRMET xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+    xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.a587cca7-b8e1-4633-b3a5-7a0e5f6e50c9"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/airmet-translation-failed.xml
+++ b/3.0.0RC1/examples/airmet-translation-failed.xml
@@ -9,11 +9,8 @@
 <iwxxm:AIRMET xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.a587cca7-b8e1-4633-b3a5-7a0e5f6e50c9"
     permissibleUsage="OPERATIONAL"
@@ -54,7 +51,27 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
+            <aixm:timeSlice>
+                <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:FIR_UIR</aixm:type>
+                    <aixm:designator>YUDD</aixm:designator>
+                    <aixm:name>SHANLON FIR/UIR</aixm:name>
+                </aixm:AirspaceTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
+
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
+
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
+            <gml:timePosition>2014-05-10T15:00:00</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.b1c4f44c-f702-43a8-95c7-79c5823d9dd0">

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -30,6 +30,13 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
 
+    <!-- the same as observationTime except for corrections/re-issuances --> 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+            <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+ 
     <!-- time at which the METAR phenomena were observed -->
     <iwxxm:observationTime>
         <gml:TimeInstant gml:id="uuid.85802aab-b4e5-4c4b-9303-10a02064e243">

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -29,20 +29,23 @@
           </aixm:timeSlice>
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
+
+    <!-- time at which the METAR phenomena were observed -->
+    <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="uuid.85802aab-b4e5-4c4b-9303-10a02064e243">
+            <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:observationTime>
+
+    <!-- Where the observation took place, assumed to be representative of the entire aerodrome -->
+    <iwxxm:observationLocation>
+        <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+            <gml:pos>12.34 -12.34</gml:pos>
+        </gml:Point>
+    </iwxxm:observationLocation>
+
     <iwxxm:observation>
         <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">
-            <!-- time at which the METAR phenomena were observed -->
-            <iwxxm:phenomenonTime>
-                <gml:TimeInstant gml:id="uuid.85802aab-b4e5-4c4b-9303-10a02064e243">
-                    <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </iwxxm:phenomenonTime>
-            <!-- Where the observation took place, assumed to be representative of the entire aerodrome -->
-            <iwxxm:observationLocation>
-                <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                    <gml:pos>12.34 -12.34</gml:pos>
-                </gml:Point>
-            </iwxxm:observationLocation>
             <iwxxm:airTemperature uom="Cel">17.0</iwxxm:airTemperature>
             <iwxxm:dewpointTemperature uom="Cel">16.0</iwxxm:dewpointTemperature>
             <iwxxm:qnh uom="hPa">1018</iwxxm:qnh>

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -5,11 +5,11 @@
       METAR YUDO 221630Z 24004MPS 0600 R12/1000U DZ FG SCT010 OVC020 17/16 Q1018
       BECMG TL1700 0800 FG BECMG AT1800 9999 NSW
 -->
-<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:xlink="http://www.w3.org/1999/xlink"
+<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.510df5de-fefb-4406-bafd-faab35333ec0"
     permissibleUsage="OPERATIONAL"
     status="NORMAL"

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -25,6 +25,11 @@
               <aixm:designator>YUDO</aixm:designator>
               <aixm:name>DONLON/INTERNATIONAL</aixm:name>
               <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+              <aixm:ARP>
+                <aixm:ElevatedPoint gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>12.34 -12.34</gml:pos>
+                </aixm:ElevatedPoint>
+              </aixm:ARP>
             </aixm:AirportHeliportTimeSlice>
           </aixm:timeSlice>
         </aixm:AirportHeliport>
@@ -43,13 +48,6 @@
             <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:observationTime>
-
-    <!-- Where the observation took place, assumed to be representative of the entire aerodrome -->
-    <iwxxm:observationLocation>
-        <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-            <gml:pos>12.34 -12.34</gml:pos>
-        </gml:Point>
-    </iwxxm:observationLocation>
 
     <iwxxm:observation>
         <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">

--- a/3.0.0RC1/examples/metar-A3-1.xml
+++ b/3.0.0RC1/examples/metar-A3-1.xml
@@ -6,164 +6,118 @@
       BECMG TL1700 0800 FG BECMG AT1800 9999 NSW
 -->
 <iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:sf="http://www.opengis.net/sampling/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.510df5de-fefb-4406-bafd-faab35333ec0"
     permissibleUsage="OPERATIONAL"
     status="NORMAL"
     automatedStation="false">
 
+    <!-- The aerodrome at which this observation took place -->
+    <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="uuid.143d63d9-15f5-442e-9bdc-1f3db93fb619">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="uuid.75c3340c-3679-4e31-8aec-efdabe375d49">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>YUDO</aixm:designator>
+              <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+              <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
     <iwxxm:observation>
-        <om:OM_Observation gml:id="uuid.461fc090-2f02-41ff-ba17-9df1e06fd759">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-            <!-- time at which the observation actually occured (same as issueTime) -->
-            <om:phenomenonTime>
-                <gml:TimeInstant gml:id="uuid.ee64f8d5-b0fd-44c9-9f6e-058adc46e425">
+        <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">
+            <!-- time at which the METAR phenomena were observed -->
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.85802aab-b4e5-4c4b-9303-10a02064e243">
                     <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-	    <!-- time at which the results of the observation are made available -->
-	    <om:resultTime xlink:href="#ti-201208221630Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.2becf617-e334-4f4d-82e8-3cad6216291b">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-            <om:featureOfInterest>
-                <!-- featureOfInterest type and shape must refer to a point -->
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.5e5af852-ee73-4b6e-95ca-f176ca22cd5d">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                    <sf:sampledFeature>
-                        <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="uuid.143d63d9-15f5-442e-9bdc-1f3db93fb619">
-                          <aixm:timeSlice>
-                            <aixm:AirportHeliportTimeSlice gml:id="uuid.75c3340c-3679-4e31-8aec-efdabe375d49">
-                              <gml:validTime/>
-                              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                              <aixm:designator>YUDO</aixm:designator>
-                              <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                              <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                            </aixm:AirportHeliportTimeSlice>
-                          </aixm:timeSlice>
-                        </aixm:AirportHeliport>
-                    </sf:sampledFeature>
-                    <sams:shape>
-                        <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                        <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                            <gml:pos>12.34 -12.34</gml:pos>
-                        </gml:Point>
-                    </sams:shape>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <!-- The result of the observation -->
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">
-                    <iwxxm:airTemperature uom="Cel">17.0</iwxxm:airTemperature>
-                    <iwxxm:dewpointTemperature uom="Cel">16.0</iwxxm:dewpointTemperature>
-                    <iwxxm:qnh uom="hPa">1018</iwxxm:qnh>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">240</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="m/s">4.0</iwxxm:meanWindSpeed>
-                        </iwxxm:AerodromeSurfaceWind>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:visibility>
-                        <iwxxm:AerodromeHorizontalVisibility>
-                            <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
-                        </iwxxm:AerodromeHorizontalVisibility>
-                    </iwxxm:visibility>
-                    <iwxxm:rvr>
-                        <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
-                            <iwxxm:runway>
-                                <aixm:RunwayDirection gml:id="uuid.f920a641-0eba-4fa3-9411-5c50444a0aa3">
-                                    <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.23b637cb-c450-4a24-83dd-ec6b965fe71d">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>12</aixm:designator>
-                                        </aixm:RunwayDirectionTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:RunwayDirection>
-                            </iwxxm:runway>
-                            <iwxxm:meanRVR uom="m">1000</iwxxm:meanRVR>
-                        </iwxxm:AerodromeRunwayVisualRange>
-                    </iwxxm:rvr>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/DZ"/>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeObservedClouds>
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
-                                    <iwxxm:base uom="[ft_i]">1000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/4"/>
-                                    <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeObservedClouds>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeObservationRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <!-- Where the observation took place, assumed to be representative of the entire aerodrome -->
+            <iwxxm:observationLocation>
+                <gml:Point gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>12.34 -12.34</gml:pos>
+                </gml:Point>
+            </iwxxm:observationLocation>
+            <iwxxm:airTemperature uom="Cel">17.0</iwxxm:airTemperature>
+            <iwxxm:dewpointTemperature uom="Cel">16.0</iwxxm:dewpointTemperature>
+            <iwxxm:qnh uom="hPa">1018</iwxxm:qnh>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">240</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="m/s">4.0</iwxxm:meanWindSpeed>
+                </iwxxm:AerodromeSurfaceWind>
+            </iwxxm:surfaceWind>
+            <iwxxm:visibility>
+                <iwxxm:AerodromeHorizontalVisibility>
+                    <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
+                </iwxxm:AerodromeHorizontalVisibility>
+            </iwxxm:visibility>
+            <iwxxm:rvr>
+                <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
+                    <iwxxm:runway>
+                        <aixm:RunwayDirection gml:id="uuid.f920a641-0eba-4fa3-9411-5c50444a0aa3">
+                            <aixm:timeSlice>
+                                <aixm:RunwayDirectionTimeSlice gml:id="uuid.23b637cb-c450-4a24-83dd-ec6b965fe71d">
+                                    <gml:validTime/>
+                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                                    <aixm:designator>12</aixm:designator>
+                                </aixm:RunwayDirectionTimeSlice>
+                            </aixm:timeSlice>
+                        </aixm:RunwayDirection>
+                    </iwxxm:runway>
+                    <iwxxm:meanRVR uom="m">1000</iwxxm:meanRVR>
+                </iwxxm:AerodromeRunwayVisualRange>
+            </iwxxm:rvr>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/DZ"/>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
+            <iwxxm:cloud>
+                <iwxxm:AerodromeObservedClouds>
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
+                            <iwxxm:base uom="[ft_i]">1000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/4"/>
+                            <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeObservedClouds>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeObservation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="uuid.dec45946-ef95-48d5-bc7a-61c801255453">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING">
             <!-- time at which the forecast conditions actually occur -->
-            <om:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.819b0c7a-133f-4029-b1d9-451be77e3c5f">
                     <gml:beginPosition>2012-08-22T16:30:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-22T17:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime xlink:href="#ti-201208221630Z"/>
-            <om:procedure xlink:href="#p-49-2-metar"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">800</iwxxm:prevailingVisibility>
-                    <iwxxm:forecastWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
-                </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">800</iwxxm:prevailingVisibility>
+            <iwxxm:forecastWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
+        </iwxxm:MeteorologicalAerodromeTrendForecast>
     </iwxxm:trendForecast>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="uuid.69a3657a-b0b5-4b12-95de-ce13422b5d86">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.be66f283-6aae-4a84-bc84-3831c9b2e7ef" changeIndicator="BECOMING">
             <!-- time at which the forecast conditions actually occur -->
-            <om:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.d4d26581-aea9-4caf-abb3-0304faac191b">
                     <gml:beginPosition>2012-08-22T18:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-22T18:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime xlink:href="#ti-201208221630Z"/>
-            <om:procedure xlink:href="#p-49-2-metar"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.be66f283-6aae-4a84-bc84-3831c9b2e7ef" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
-                    <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
-                    <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
-                </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+            <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
+            <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+        </iwxxm:MeteorologicalAerodromeTrendForecast>
     </iwxxm:trendForecast>
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
+++ b/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
@@ -28,6 +28,13 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
     
+    <!-- the same as observationTime except for corrections/re-issuances --> 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+            <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:observationTime>
         <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
             <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>

--- a/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
+++ b/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
@@ -23,6 +23,11 @@
                     <aixm:designator>EDDF</aixm:designator>
                     <aixm:name>FRANKFURT AM MAIN INTERNATIONAL</aixm:name>
                     <aixm:locationIndicatorICAO>EDDF</aixm:locationIndicatorICAO>
+                    <aixm:ARP>
+                        <aixm:ElevatedPoint gml:id="uuid.68f896c8-6889-4b5b-8d79-1f1216ceb72f" srsDimension="3" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+                            <gml:pos>50.0464 8.5986 112</gml:pos>
+                        </aixm:ElevatedPoint>
+                    </aixm:ARP>
                 </aixm:AirportHeliportTimeSlice>
             </aixm:timeSlice>
         </aixm:AirportHeliport>
@@ -40,16 +45,6 @@
             <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:observationTime>
-    
-    <iwxxm:observationLocation>
-        <gml:Point gml:id="uuid.68f896c8-6889-4b5b-8d79-1f1216ceb72f"
-            uomLabels="deg deg m"
-            axisLabels="Lat Lon Altitude"
-            srsDimension="3"
-            srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-            <gml:pos>50.0464 8.5986 112</gml:pos>
-        </gml:Point>
-    </iwxxm:observationLocation>
     
     <iwxxm:observation>
         <iwxxm:MeteorologicalAerodromeObservation cloudAndVisibilityOK="false"

--- a/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
+++ b/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
@@ -4,13 +4,13 @@
     resulting METAR (FM 15):
     METAR EDDF 120550Z 03015KT 1400 R07R/P2000N R07C/P2000N R07L/1900U SN DRSN BR VV/// M04/M04 Q1000 R07R/11//90 R07C/15//90 R07L/15//90 BECMG 4000 NSW
 -->
-<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.96a5ba6a-47ce-4c10-bc56-355a32dcf22c" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
     
     <iwxxm:aerodrome>

--- a/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
+++ b/3.0.0RC1/examples/metar-EDDF-runwaystate.xml
@@ -7,184 +7,157 @@
 <iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:sam="http://www.opengis.net/sampling/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.96a5ba6a-47ce-4c10-bc56-355a32dcf22c" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
+    
+    <iwxxm:aerodrome>
+        <!-- The aerodrome at which this observation took place -->
+        <aixm:AirportHeliport gml:id="uuid.124c4e83-3137-450e-aab3-3259d92282fd">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.7287c97c-321e-42df-8e50-d6068c6e12b0">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>EDDF</aixm:designator>
+                    <aixm:name>FRANKFURT AM MAIN INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>EDDF</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
+    
+    <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
+            <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:observationTime>
+    
+    <iwxxm:observationLocation>
+        <gml:Point gml:id="uuid.68f896c8-6889-4b5b-8d79-1f1216ceb72f"
+            uomLabels="deg deg m"
+            axisLabels="Lat Lon Altitude"
+            srsDimension="3"
+            srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+            <gml:pos>50.0464 8.5986 112</gml:pos>
+        </gml:Point>
+    </iwxxm:observationLocation>
+    
     <iwxxm:observation>
-        <om:OM_Observation gml:id="uuid.699aaad3-e7f0-42af-9203-79d9daf71b47">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-            <om:phenomenonTime>
-                <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
-                    <gml:timePosition>2013-03-12T05:50:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:phenomenonTime>
-            <om:resultTime xlink:href="#ti-20130312T055000Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.9413b38a-c725-4d18-8dad-4e3eb45f3818">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.d7f17da6-7ead-4c19-95ab-449a7d5759cc">
-                    <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                    <sam:sampledFeature>
-                        <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="uuid.124c4e83-3137-450e-aab3-3259d92282fd">
+        <iwxxm:MeteorologicalAerodromeObservation cloudAndVisibilityOK="false"
+            gml:id="uuid.5980a075-9a27-4da7-b657-8c8f7032f24c">
+            
+            <iwxxm:airTemperature uom="Cel">-4</iwxxm:airTemperature>
+            <iwxxm:dewpointTemperature uom="Cel">-4</iwxxm:dewpointTemperature>
+            <iwxxm:qnh uom="hPa">1000</iwxxm:qnh>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">30</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="[kn_i]">15</iwxxm:meanWindSpeed>
+                </iwxxm:AerodromeSurfaceWind>
+            </iwxxm:surfaceWind>
+            <iwxxm:visibility>
+                <iwxxm:AerodromeHorizontalVisibility>
+                    <iwxxm:prevailingVisibility uom="m">1400</iwxxm:prevailingVisibility>
+                </iwxxm:AerodromeHorizontalVisibility>
+            </iwxxm:visibility>
+
+            <iwxxm:rvr>
+                <iwxxm:AerodromeRunwayVisualRange pastTendency="NO_CHANGE">
+                    <iwxxm:runway xlink:href="#runway-eddf-07-r-sf" />
+                    <iwxxm:meanRVR uom="m">2000</iwxxm:meanRVR>
+                    <iwxxm:meanRVROperator>ABOVE</iwxxm:meanRVROperator>
+                </iwxxm:AerodromeRunwayVisualRange>
+            </iwxxm:rvr>
+            <iwxxm:rvr>
+                <iwxxm:AerodromeRunwayVisualRange pastTendency="NO_CHANGE">
+                    <iwxxm:runway xlink:href="#runway-EDDF-07-c-sf" />
+                    <iwxxm:meanRVR uom="m">2000</iwxxm:meanRVR>
+                    <iwxxm:meanRVROperator>ABOVE</iwxxm:meanRVROperator>
+                </iwxxm:AerodromeRunwayVisualRange>
+            </iwxxm:rvr>
+            <iwxxm:rvr>
+                <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
+                    <iwxxm:runway xlink:href="#runway-EDDF-07-l-sf" />
+                    <iwxxm:meanRVR uom="m">1900</iwxxm:meanRVR>
+                </iwxxm:AerodromeRunwayVisualRange>
+            </iwxxm:rvr>
+
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/SN"/>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/DRSN"/>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/BR"/>
+
+            <iwxxm:cloud>
+                <iwxxm:AerodromeObservedClouds>
+                  <iwxxm:verticalVisibility uom="N/A" xsi:nil="true" nilReason="http://codes.wmo.int/common/nil/notObservable"/>
+                </iwxxm:AerodromeObservedClouds>
+             </iwxxm:cloud>
+            <iwxxm:runwayState>
+                <iwxxm:AerodromeRunwayState>
+                    <iwxxm:runway>
+                        <aixm:RunwayDirection  gml:id="uuid.f1ff030c-1e4c-40a5-be9a-fbb714369f7f">
                             <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="uuid.7287c97c-321e-42df-8e50-d6068c6e12b0">
+                                <aixm:RunwayDirectionTimeSlice gml:id="uuid.0c695aa2-df15-421d-a616-ca510b356098">
                                     <gml:validTime/>
                                     <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:designator>EDDF</aixm:designator>
-                                    <aixm:name>FRANKFURT AM MAIN INTERNATIONAL</aixm:name>
-                                    <aixm:locationIndicatorICAO>EDDF</aixm:locationIndicatorICAO>
-                                </aixm:AirportHeliportTimeSlice>
+                                    <aixm:designator>07R</aixm:designator>
+                                    <aixm:trueBearing>70</aixm:trueBearing>
+                                </aixm:RunwayDirectionTimeSlice>
                             </aixm:timeSlice>
-                        </aixm:AirportHeliport>
-                     </sam:sampledFeature>
-                    <sams:shape>
-                        <gml:Point gml:id="uuid.68f896c8-6889-4b5b-8d79-1f1216ceb72f"
-                            uomLabels="deg deg m"
-                            axisLabels="Lat Lon Altitude"
-                            srsDimension="3"
-                            srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-                            <gml:pos>50.0464 8.5986 112</gml:pos>
-                        </gml:Point>
-                    </sams:shape>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
+                        </aixm:RunwayDirection>
+                    </iwxxm:runway>
+                    <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
+                    <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/1"/>
+                    <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
+                </iwxxm:AerodromeRunwayState>
+            </iwxxm:runwayState>
+            <iwxxm:runwayState>
+                <iwxxm:AerodromeRunwayState>
+                    <iwxxm:runway>
+                        <aixm:RunwayDirection  gml:id="uuid.46f64d66-03fb-4469-85a2-ab712aa8a7ff">
+                            <aixm:timeSlice>
+                                <aixm:RunwayDirectionTimeSlice gml:id="uuid.26b44940-55b0-4f4f-805c-3b40af52694e">
+                                    <gml:validTime/>
+                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                                    <aixm:designator>07C</aixm:designator>
+                                    <aixm:trueBearing>70</aixm:trueBearing>
+                                </aixm:RunwayDirectionTimeSlice>
+                            </aixm:timeSlice>
+                        </aixm:RunwayDirection>
+                    </iwxxm:runway>
+                    <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
+                    <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/5"/>
+                    <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
+                </iwxxm:AerodromeRunwayState>
+            </iwxxm:runwayState>
+            <iwxxm:runwayState>
+                <iwxxm:AerodromeRunwayState>
+                    <iwxxm:runway>
+                        <aixm:RunwayDirection  gml:id="uuid.fa34a796-e0d1-409d-a544-90d6787d46ca">
+                            <aixm:timeSlice>
+                                <aixm:RunwayDirectionTimeSlice gml:id="uuid.6c4abb3b-e4a0-48e0-a058-314c3f2ef3e6">
+                                    <gml:validTime/>
+                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                                    <aixm:designator>07L</aixm:designator>
+                                    <aixm:trueBearing>70</aixm:trueBearing>
+                                </aixm:RunwayDirectionTimeSlice>
+                            </aixm:timeSlice>
+                        </aixm:RunwayDirection>
+                    </iwxxm:runway>
+                    <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
+                    <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/5"/>
+                    <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
+                </iwxxm:AerodromeRunwayState>
+            </iwxxm:runwayState>
 
-                <iwxxm:MeteorologicalAerodromeObservationRecord cloudAndVisibilityOK="false"
-                    gml:id="uuid.5980a075-9a27-4da7-b657-8c8f7032f24c">
-                    <iwxxm:airTemperature uom="Cel">-4</iwxxm:airTemperature>
-                    <iwxxm:dewpointTemperature uom="Cel">-4</iwxxm:dewpointTemperature>
-                    <iwxxm:qnh uom="hPa">1000</iwxxm:qnh>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">30</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="[kn_i]">15</iwxxm:meanWindSpeed>
-                        </iwxxm:AerodromeSurfaceWind>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:visibility>
-                        <iwxxm:AerodromeHorizontalVisibility>
-                            <iwxxm:prevailingVisibility uom="m">1400</iwxxm:prevailingVisibility>
-                        </iwxxm:AerodromeHorizontalVisibility>
-                    </iwxxm:visibility>
-
-                    <iwxxm:rvr>
-                        <iwxxm:AerodromeRunwayVisualRange pastTendency="NO_CHANGE">
-                            <iwxxm:runway xlink:href="#runway-eddf-07-r-sf" />
-                            <iwxxm:meanRVR uom="m">2000</iwxxm:meanRVR>
-                            <iwxxm:meanRVROperator>ABOVE</iwxxm:meanRVROperator>
-                        </iwxxm:AerodromeRunwayVisualRange>
-                    </iwxxm:rvr>
-                    <iwxxm:rvr>
-                        <iwxxm:AerodromeRunwayVisualRange pastTendency="NO_CHANGE">
-                            <iwxxm:runway xlink:href="#runway-EDDF-07-c-sf" />
-                            <iwxxm:meanRVR uom="m">2000</iwxxm:meanRVR>
-                            <iwxxm:meanRVROperator>ABOVE</iwxxm:meanRVROperator>
-                        </iwxxm:AerodromeRunwayVisualRange>
-                    </iwxxm:rvr>
-                    <iwxxm:rvr>
-                        <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
-                            <iwxxm:runway xlink:href="#runway-EDDF-07-l-sf" />
-                            <iwxxm:meanRVR uom="m">1900</iwxxm:meanRVR>
-                        </iwxxm:AerodromeRunwayVisualRange>
-                    </iwxxm:rvr>
-
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/SN"/>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/DRSN"/>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/BR"/>
-
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeObservedClouds>
-                          <iwxxm:verticalVisibility uom="N/A" xsi:nil="true" nilReason="http://codes.wmo.int/common/nil/notObservable"/>
-                        </iwxxm:AerodromeObservedClouds>
-                     </iwxxm:cloud>
-                    <iwxxm:runwayState>
-                        <iwxxm:AerodromeRunwayState>
-                            <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="uuid.f1ff030c-1e4c-40a5-be9a-fbb714369f7f">
-                                    <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.0c695aa2-df15-421d-a616-ca510b356098">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>07R</aixm:designator>
-                                            <aixm:trueBearing>70</aixm:trueBearing>
-                                        </aixm:RunwayDirectionTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:RunwayDirection>
-                            </iwxxm:runway>
-                            <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
-                            <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/1"/>
-                            <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
-                        </iwxxm:AerodromeRunwayState>
-                    </iwxxm:runwayState>
-                    <iwxxm:runwayState>
-                        <iwxxm:AerodromeRunwayState>
-                            <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="uuid.46f64d66-03fb-4469-85a2-ab712aa8a7ff">
-                                    <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.26b44940-55b0-4f4f-805c-3b40af52694e">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>07C</aixm:designator>
-                                            <aixm:trueBearing>70</aixm:trueBearing>
-                                        </aixm:RunwayDirectionTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:RunwayDirection>
-                            </iwxxm:runway>
-                            <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
-                            <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/5"/>
-                            <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
-                        </iwxxm:AerodromeRunwayState>
-                    </iwxxm:runwayState>
-                    <iwxxm:runwayState>
-                        <iwxxm:AerodromeRunwayState>
-                            <iwxxm:runway>
-                                <aixm:RunwayDirection  gml:id="uuid.fa34a796-e0d1-409d-a544-90d6787d46ca">
-                                    <aixm:timeSlice>
-                                        <aixm:RunwayDirectionTimeSlice gml:id="uuid.6c4abb3b-e4a0-48e0-a058-314c3f2ef3e6">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>07L</aixm:designator>
-                                            <aixm:trueBearing>70</aixm:trueBearing>
-                                        </aixm:RunwayDirectionTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:RunwayDirection>
-                            </iwxxm:runway>
-                            <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
-                            <iwxxm:contamination xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-087/5"/>
-                            <iwxxm:estimatedSurfaceFrictionOrBrakingAction xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-089/90"/>
-                        </iwxxm:AerodromeRunwayState>
-                    </iwxxm:runwayState>
-
-                </iwxxm:MeteorologicalAerodromeObservationRecord>
-            </om:result>
-        </om:OM_Observation>
+        </iwxxm:MeteorologicalAerodromeObservation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="uuid.8dfbd54a-a482-4fe3-bc32-1ca3794b9f14">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
-            <om:phenomenonTime nilReason="unknown"/>
-            <om:resultTime xlink:href="#ti-20130312T055000Z"/>
-            <om:procedure xlink:href="#p-49-2-metar"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
-            <om:featureOfInterest xlink:href="#sp-EDDF"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.83222aab-9e5f-4296-a7f5-3d7e2af4ae45" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">4000</iwxxm:prevailingVisibility>
-                    <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
-                </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.83222aab-9e5f-4296-a7f5-3d7e2af4ae45" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+            <iwxxm:phenomenonTime nilReason="unknown"/>
+            <iwxxm:prevailingVisibility uom="m">4000</iwxxm:prevailingVisibility>
+            <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+        </iwxxm:MeteorologicalAerodromeTrendForecast>
     </iwxxm:trendForecast>
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/metar-LKKV.xml
+++ b/3.0.0RC1/examples/metar-LKKV.xml
@@ -2,101 +2,81 @@
 <iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:sam="http://www.opengis.net/sampling/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.ce3b61b9-d360-4da1-83b9-67e668406869" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
+    
+    <iwxxm:aerodrome>
+        <!-- The aerodrome at which this observation took place -->
+        <aixm:AirportHeliport gml:id="uuid.249725b7-1d1f-4431-8ff0-bbbe65c5f5c0">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.c69cbe8a-81da-4ddc-a4a8-995e052327d2">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>LKKV</aixm:designator>
+                    <aixm:name>KARLOVY VARY INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>LKKV</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
+    
+    <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="uuid.27e26b04-27e7-4c41-adaa-2b16ba92e310">
+            <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:observationTime>
+    
+    <!-- Location not known by issuer -->
+    <iwxxm:observationLocation nilReason="unknown"/>
+    
     <iwxxm:observation>
-        <om:OM_Observation gml:id="uuid.f1ee2439-7dc2-478d-9a42-1a4577e83146">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-            <om:phenomenonTime>
-                <gml:TimeInstant gml:id="uuid.27e26b04-27e7-4c41-adaa-2b16ba92e310">
-                    <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:phenomenonTime>
-            <om:resultTime xlink:href="#ti-20070725T12Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.a931097a-48a9-4f31-99c3-ed4ca3da8c09">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.77f712fd-f7fd-4762-812a-70acc7103af5">
-                    <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                    <sam:sampledFeature>
-                        <aixm:AirportHeliport gml:id="uuid.249725b7-1d1f-4431-8ff0-bbbe65c5f5c0">
-                            <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="uuid.c69cbe8a-81da-4ddc-a4a8-995e052327d2">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:designator>LKKV</aixm:designator>
-                                    <aixm:name>KARLOVY VARY INTERNATIONAL</aixm:name>
-                                    <aixm:locationIndicatorICAO>LKKV</aixm:locationIndicatorICAO>
-                                </aixm:AirportHeliportTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:AirportHeliport>
-                    </sam:sampledFeature>
-                    <sams:shape>
-                        <gml:Point gml:id="uuid.70c31fd7-c5cf-4c64-ad24-67f2ce15b0e6" uomLabels="deg deg m" axisLabels="Lat Lon Altitude" srsDimension="3" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-                            <gml:pos>50.20 12.92 606</gml:pos>
-                        </gml:Point>
-                    </sams:shape>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord cloudAndVisibilityOK="false" gml:id="uuid.dccac4d8-c332-4353-997b-822db356eafa">
-                    <iwxxm:airTemperature uom="Cel">27</iwxxm:airTemperature>
-                    <iwxxm:dewpointTemperature uom="Cel">10</iwxxm:dewpointTemperature>
-                    <iwxxm:qnh uom="hPa">1010</iwxxm:qnh>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">210</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="m/s">2.6</iwxxm:meanWindSpeed>
-                        </iwxxm:AerodromeSurfaceWind>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/VCSH"/>
-                    <iwxxm:recentWeather xlink:href="http://codes.wmo.int/306/4678/TS"/>
-                    <!-- WS R18C -->
-                    <iwxxm:windShear>
-                      <iwxxm:AerodromeWindShear>
-                        <iwxxm:runway>
-                          <aixm:RunwayDirection gml:id="uuid.3f6809e8-12e1-49ec-a2de-a714fd66fd07">
-                            <aixm:timeSlice>
-                              <aixm:RunwayDirectionTimeSlice gml:id="uuid.6e500b68-defe-453a-8569-e6efa8d903f1">
-                                <gml:validTime/>
-                                <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                <aixm:designator>18C</aixm:designator>
+        <iwxxm:MeteorologicalAerodromeObservation cloudAndVisibilityOK="false" gml:id="uuid.dccac4d8-c332-4353-997b-822db356eafa">
+            <iwxxm:airTemperature uom="Cel">27</iwxxm:airTemperature>
+            <iwxxm:dewpointTemperature uom="Cel">10</iwxxm:dewpointTemperature>
+            <iwxxm:qnh uom="hPa">1010</iwxxm:qnh>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">210</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="m/s">2.6</iwxxm:meanWindSpeed>
+                </iwxxm:AerodromeSurfaceWind>
+            </iwxxm:surfaceWind>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/VCSH"/>
+            <iwxxm:recentWeather xlink:href="http://codes.wmo.int/306/4678/TS"/>
+            <!-- WS R18C -->
+            <iwxxm:windShear>
+              <iwxxm:AerodromeWindShear>
+                <iwxxm:runway>
+                  <aixm:RunwayDirection gml:id="uuid.3f6809e8-12e1-49ec-a2de-a714fd66fd07">
+                    <aixm:timeSlice>
+                      <aixm:RunwayDirectionTimeSlice gml:id="uuid.6e500b68-defe-453a-8569-e6efa8d903f1">
+                        <gml:validTime/>
+                        <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                        <aixm:designator>18C</aixm:designator>
+                      </aixm:RunwayDirectionTimeSlice>
+                    </aixm:timeSlice>
+                  </aixm:RunwayDirection>
+                </iwxxm:runway>
+              </iwxxm:AerodromeWindShear>
+            </iwxxm:windShear>
+          <iwxxm:runwayState>
+                <iwxxm:AerodromeRunwayState>
+                    <iwxxm:runway>
+                      <aixm:RunwayDirection gml:id="uuid.4ce3040f-69a1-4703-8a21-78a33c14ddce">
+                          <aixm:timeSlice>
+                              <aixm:RunwayDirectionTimeSlice gml:id="uuid.da0eb705-ba52-4d66-8d0d-130b99be5692">
+                                  <gml:validTime/>
+                                  <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                                  <aixm:designator>11</aixm:designator>
                               </aixm:RunwayDirectionTimeSlice>
-                            </aixm:timeSlice>
-                          </aixm:RunwayDirection>
-                        </iwxxm:runway>
-                      </iwxxm:AerodromeWindShear>
-                    </iwxxm:windShear>
-                  <iwxxm:runwayState>
-                        <iwxxm:AerodromeRunwayState>
-                            <iwxxm:runway>
-                              <aixm:RunwayDirection gml:id="uuid.4ce3040f-69a1-4703-8a21-78a33c14ddce">
-                                  <aixm:timeSlice>
-                                      <aixm:RunwayDirectionTimeSlice gml:id="uuid.da0eb705-ba52-4d66-8d0d-130b99be5692">
-                                          <gml:validTime/>
-                                          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                          <aixm:designator>11</aixm:designator>
-                                      </aixm:RunwayDirectionTimeSlice>
-                                  </aixm:timeSlice>
-                              </aixm:RunwayDirection>
-                            </iwxxm:runway>
-                            <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
-                        </iwxxm:AerodromeRunwayState>
-                    </iwxxm:runwayState>
-                </iwxxm:MeteorologicalAerodromeObservationRecord>
-            </om:result>
-        </om:OM_Observation>
+                          </aixm:timeSlice>
+                      </aixm:RunwayDirection>
+                    </iwxxm:runway>
+                    <iwxxm:depositType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-086/1"/>
+                </iwxxm:AerodromeRunwayState>
+            </iwxxm:runwayState>
+        </iwxxm:MeteorologicalAerodromeObservation>
     </iwxxm:observation>
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/metar-LKKV.xml
+++ b/3.0.0RC1/examples/metar-LKKV.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.ce3b61b9-d360-4da1-83b9-67e668406869" status="NORMAL" automatedStation="false" permissibleUsage="OPERATIONAL">
     
     <iwxxm:aerodrome>

--- a/3.0.0RC1/examples/metar-LKKV.xml
+++ b/3.0.0RC1/examples/metar-LKKV.xml
@@ -18,6 +18,7 @@
                     <aixm:designator>LKKV</aixm:designator>
                     <aixm:name>KARLOVY VARY INTERNATIONAL</aixm:name>
                     <aixm:locationIndicatorICAO>LKKV</aixm:locationIndicatorICAO>
+                    <!-- ARP not known by issuer -->
                 </aixm:AirportHeliportTimeSlice>
             </aixm:timeSlice>
         </aixm:AirportHeliport>
@@ -35,9 +36,6 @@
             <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
         </gml:TimeInstant>
     </iwxxm:observationTime>
-    
-    <!-- Location not known by issuer -->
-    <iwxxm:observationLocation nilReason="unknown"/>
     
     <iwxxm:observation>
         <iwxxm:MeteorologicalAerodromeObservation cloudAndVisibilityOK="false" gml:id="uuid.dccac4d8-c332-4353-997b-822db356eafa">

--- a/3.0.0RC1/examples/metar-LKKV.xml
+++ b/3.0.0RC1/examples/metar-LKKV.xml
@@ -23,6 +23,13 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
     
+    <!-- the same as observationTime except for corrections/re-issuances --> 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+            <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:observationTime>
         <gml:TimeInstant gml:id="uuid.27e26b04-27e7-4c41-adaa-2b16ba92e310">
             <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>

--- a/3.0.0RC1/examples/metar-NIL-collect.xml
+++ b/3.0.0RC1/examples/metar-NIL-collect.xml
@@ -15,11 +15,11 @@
     <collect:meteorologicalInformation>
 
         <iwxxm:METAR
-            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0"
             xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
             xmlns:gml="http://www.opengis.net/gml/3.2"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.15ff064a-6dc4-41e0-bafa-8ee78ed4dc25"
             status="MISSING"
             permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/metar-NIL-collect.xml
+++ b/3.0.0RC1/examples/metar-NIL-collect.xml
@@ -54,8 +54,6 @@
                 </gml:TimeInstant>
             </iwxxm:observationTime>
             
-            <iwxxm:observationLocation nilReason="missing"/>
-
             <!-- NIL/missing reports do not have reported weather conditions -->
             <iwxxm:observation nilReason="missing"/>
         </iwxxm:METAR>

--- a/3.0.0RC1/examples/metar-NIL-collect.xml
+++ b/3.0.0RC1/examples/metar-NIL-collect.xml
@@ -6,77 +6,51 @@
       METAR YUDO 221630Z NIL
 -->
 <collect:MeteorologicalBulletin
-    xmlns:collect="http://def.wmo.int/collect/2014"
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-                        http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
-			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
-    gml:id="uuid.6f353602-12a1-40a7-b6b5-3edb14c6241e">
+        xmlns:collect="http://def.wmo.int/collect/2014"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
+        gml:id="uuid.6f353602-12a1-40a7-b6b5-3edb14c6241e">
 
     <collect:meteorologicalInformation>
 
-        <iwxxm:METAR 
+        <iwxxm:METAR
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+            xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.15ff064a-6dc4-41e0-bafa-8ee78ed4dc25"
             status="MISSING"
             permissibleUsage="OPERATIONAL"
             automatedStation="false">
-        
-            <iwxxm:observation>
-                <om:OM_Observation gml:id="uuid.81ac9ff7-a1ba-4124-a8fe-bc29794cd381">
-                    <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-                    <!-- time at which the observation of the missing should occur (same as issueTime) -->
-                    <om:phenomenonTime>
-                        <gml:TimeInstant gml:id="uuid.63a9f14f-f5bd-4b7f-a5b4-df85ecad4c32">
-                            <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
-                        </gml:TimeInstant>
-                    </om:phenomenonTime>
-                    <!-- time at which the results of the observation are made available -->
-		    <om:resultTime xlink:href="#ti-201208221630Z"/>
-		    <om:procedure>
-                        <metce:Process gml:id="uuid.f1b88806-76ad-41a7-8d18-55dfd332a98c">
-                            <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-                        </metce:Process>
-                    </om:procedure>
-                    <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-                    <om:featureOfInterest>
-                        <!-- featureOfInterest type and shape must refer to a point -->
-                        <sams:SF_SpatialSamplingFeature gml:id="uuid.4161385c-f76e-484b-b092-035355cf38c1">
-                            <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                            <sf:sampledFeature>
-                                <!-- The aerodrome at which this observation took place -->
-                                <aixm:AirportHeliport gml:id="uuid.2cb49495-cbc5-4bc8-aaf6-334fd9268391">
-                                    <aixm:timeSlice>
-                                        <aixm:AirportHeliportTimeSlice gml:id="uuid.1c046a98-8714-4038-b5fc-46c97bac0f4f">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>YUDO</aixm:designator>
-                                            <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                                            <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                                        </aixm:AirportHeliportTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:AirportHeliport>
-                            </sf:sampledFeature>
-                            <sams:shape>
-                                <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                                <gml:Point gml:id="uuid.c3de1912-8b52-4c98-b201-0b4208f9bac1" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:pos>12.34 -12.34</gml:pos>
-                                </gml:Point>
-                            </sams:shape>
-                        </sams:SF_SpatialSamplingFeature>
-                    </om:featureOfInterest>
-                    <!-- The result of the observation -->
-                    <om:result nilReason="missing"/>
-                </om:OM_Observation>
-            </iwxxm:observation>
+
+            <iwxxm:aerodrome>
+                <!-- The aerodrome at which this observation took place -->
+                <aixm:AirportHeliport gml:id="uuid.2cb49495-cbc5-4bc8-aaf6-334fd9268391">
+                    <aixm:timeSlice>
+                        <aixm:AirportHeliportTimeSlice gml:id="uuid.1c046a98-8714-4038-b5fc-46c97bac0f4f">
+                            <gml:validTime/>
+                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                            <aixm:designator>YUDO</aixm:designator>
+                            <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                            <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                        </aixm:AirportHeliportTimeSlice>
+                    </aixm:timeSlice>
+                </aixm:AirportHeliport>
+            </iwxxm:aerodrome>
+
+            <!-- time at which the observation occurred -->
+            <iwxxm:observationTime>
+                <gml:TimeInstant gml:id="uuid.63a9f14f-f5bd-4b7f-a5b4-df85ecad4c32">
+                    <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:observationTime>
+            
+            <iwxxm:observationLocation nilReason="missing"/>
+
+            <!-- NIL/missing reports do not have reported weather conditions -->
+            <iwxxm:observation nilReason="missing"/>
         </iwxxm:METAR>
 
     </collect:meteorologicalInformation>

--- a/3.0.0RC1/examples/metar-NIL-collect.xml
+++ b/3.0.0RC1/examples/metar-NIL-collect.xml
@@ -39,6 +39,13 @@
                     </aixm:timeSlice>
                 </aixm:AirportHeliport>
             </iwxxm:aerodrome>
+            
+            <!-- the same as observationTime except for corrections/re-issuances --> 
+            <iwxxm:issueTime>
+                <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+                    <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:issueTime>
 
             <!-- time at which the observation occurred -->
             <iwxxm:observationTime>

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -4,11 +4,11 @@
     
       METAR YUDO 221630Z INVALID
 -->
-<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
+<iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.4324ada0-ddfc-4206-9689-3aa8b58649fd"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -35,6 +35,13 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
     
+    <!-- the same as observationTime except for corrections/re-issuances --> 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+            <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:observationTime>
         <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
             <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -5,13 +5,10 @@
       METAR YUDO 221630Z INVALID
 -->
 <iwxxm:METAR xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013" xmlns:sf="http://www.opengis.net/sampling/2.0"
+    xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.4324ada0-ddfc-4206-9689-3aa8b58649fd"
     permissibleUsage="OPERATIONAL"
@@ -22,47 +19,30 @@
     translationTime="2014-05-15T15:30:00Z"
     translationFailedTAC="METAR YUDO 221630Z INVALID"
     status="NORMAL">
-  
-  <iwxxm:observation>
-    <om:OM_Observation gml:id="uuid.cab9a958-ddbe-4ec3-818e-20c8088a2ab6">
-      <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.46784d6c-e625-4ea7-86cc-a3cc1bdbe4b4">
-          <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:phenomenonTime>
-      <om:resultTime>
-        <gml:TimeInstant gml:id="uuid.3df8b70f-ba69-4ed0-a45e-e46a8009b674">
-          <gml:timePosition>2012-08-22T16:40:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:resultTime>
-      <om:procedure>
-        <metce:Process gml:id="uuid.aa8790c9-7745-48a2-9b87-3d7c6c576a42">
-          <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-        </metce:Process>
-      </om:procedure>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-      <om:featureOfInterest>
-        <sams:SF_SpatialSamplingFeature gml:id="uuid.a562f2e4-b2c9-44c3-9c63-f96cbbb4b11c">
-          <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-          <sf:sampledFeature>
-            <aixm:AirportHeliport gml:id="uuid.7a8db8f9-281a-40ca-a443-40253790bfff">
-              <aixm:timeSlice>
+    
+    <iwxxm:aerodrome>
+        <!-- The aerodrome at which this observation took place -->
+        <aixm:AirportHeliport gml:id="uuid.7a8db8f9-281a-40ca-a443-40253790bfff">
+            <aixm:timeSlice>
                 <aixm:AirportHeliportTimeSlice gml:id="uuid.6656af3d-e836-49d9-a7f1-f8c8b23790f9">
-                  <gml:validTime/>
-                  <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                  <aixm:designator>YUDO</aixm:designator>
-                  <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                  <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>YUDO</aixm:designator>
+                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
                 </aixm:AirportHeliportTimeSlice>
-              </aixm:timeSlice>
-            </aixm:AirportHeliport>
-          </sf:sampledFeature>
-          <sams:shape/>
-        </sams:SF_SpatialSamplingFeature>
-      </om:featureOfInterest>
-      <om:result nilReason="missing"/>
-    </om:OM_Observation>
-  </iwxxm:observation>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
+    
+    <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="uuid.064bf483-439b-4e40-91b8-8aadd0638d92">
+            <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:observationTime>
+    
+    <iwxxm:observationLocation nilReason="missing"/>
+  
+    <iwxxm:observation nilReason="missing"/>
 
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -48,8 +48,6 @@
         </gml:TimeInstant>
     </iwxxm:observationTime>
     
-    <iwxxm:observationLocation nilReason="missing"/>
-  
     <iwxxm:observation nilReason="missing"/>
 
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
@@ -5,11 +5,11 @@
       YUDD SIGMET 2 VALID 101200/101600 YUSO –
       YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN
 -->
-<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.8debfaca-7116-4b32-9378-b472ca64e823"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
@@ -51,6 +51,7 @@
                     <aixm:type>OTHER:FIR_UIR</aixm:type>
                     <aixm:designator>YUDD</aixm:designator>
                     <aixm:name>SHANLON FIR/UIR</aixm:name>
+                    <!-- FIR boundary can be reported in an aixm:geometryComponent -->
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>

--- a/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
@@ -15,6 +15,13 @@
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.7754148a-7769-4adc-93fc-d591bf19c715">
+            <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.fb27bee4-d1a0-4e47-87b3-7dbd863a55bf">
             <aixm:timeSlice>
@@ -42,7 +49,7 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.e8411dad-219a-4018-ad55-c5791a87c86d">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.de6d3114-bafe-47d6-a47f-2fbe43581a54">
@@ -55,16 +62,9 @@
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
 
     <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
-
-    <!-- time at which the results of the observation were made available (issued) -->
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.7754148a-7769-4adc-93fc-d591bf19c715">
-            <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>

--- a/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1a-TS.xml
@@ -7,13 +7,9 @@
 -->
 <iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.8debfaca-7116-4b32-9378-b472ca64e823"
     permissibleUsage="OPERATIONAL"
@@ -46,7 +42,28 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.e8411dad-219a-4018-ad55-c5791a87c86d">
+            <aixm:timeSlice>
+                <aixm:AirspaceTimeSlice gml:id="uuid.de6d3114-bafe-47d6-a47f-2fbe43581a54">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:FIR_UIR</aixm:type>
+                    <aixm:designator>YUDD</aixm:designator>
+                    <aixm:name>SHANLON FIR/UIR</aixm:name>
+                </aixm:AirspaceTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
+
     <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
+
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.7754148a-7769-4adc-93fc-d591bf19c715">
+            <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
@@ -61,80 +78,39 @@
 
     <!-- FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="uuid.3c96a88a-8388-40d3-8d1d-fb5f69d071d7">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
+        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.06446fea-1935-4101-b3e8-74f286a9b74d" timeIndicator="FORECAST">
             <!-- time of FCST conditions - if missing there is no FCST or OBS time -->
-            <om:phenomenonTime nilReason="missing"/>
-
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.7754148a-7769-4adc-93fc-d591bf19c715">
-                    <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <!-- The valid period for this observation is the period of the entire SIGMET -->
-            <om:validTime xlink:href="#tp-20120810T1200Z-20120810T1600Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.e5f851f2-4e6d-4656-bd45-77fc6fdc6388">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.44664773-df86-400b-9c97-37764b7245ba">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-                    <sf:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.e8411dad-219a-4018-ad55-c5791a87c86d">
-                            <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="uuid.de6d3114-bafe-47d6-a47f-2fbe43581a54">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:type>OTHER:FIR_UIR</aixm:type>
-                                    <aixm:designator>YUDD</aixm:designator>
-                                    <aixm:name>SHANLON FIR/UIR</aixm:name>
-                                </aixm:AirspaceTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:Airspace>
-                    </sf:sampledFeature>
-                    <!-- FIR boundary - not typically reported -->
-                    <sams:shape nilReason="withheld"/>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.06446fea-1935-4101-b3e8-74f286a9b74d" timeIndicator="FORECAST">
-                  <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.10f68782-703d-43a6-a4e5-af27469edc6e" intensityChange="WEAKEN">
-                      <iwxxm:directionOfMotion uom="deg">90</iwxxm:directionOfMotion>
-                      <!-- This shape describes: S OF N54 AND E OF W012 TOP FL390 -->
-                      <iwxxm:geometry>
+            <iwxxm:phenomenonTime nilReason="missing"/>
+            <iwxxm:member>
+                <iwxxm:SIGMETEvolvingCondition gml:id="uuid.10f68782-703d-43a6-a4e5-af27469edc6e" intensityChange="WEAKEN">
+                    <iwxxm:directionOfMotion uom="deg">90</iwxxm:directionOfMotion>
+                    <!-- This shape describes: S OF N54 AND E OF W012 TOP FL390 -->
+                    <iwxxm:geometry>
                         <aixm:AirspaceVolume gml:id="uuid.d4938cc8-c129-4cd7-bda5-588c434ef996">
-                          <aixm:upperLimit uom="FL">390</aixm:upperLimit>
-                          <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                          <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="uuid.e20caa4b-2b93-4d28-9b14-e04196314999" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
-                                <gml:PolygonPatch>
-                                  <gml:exterior>
-                                    <gml:LinearRing>
-                                      <!-- bounding polygon clipped to edge of FIR @ 50N and 08W (in clockwise order) -->
-                                      <gml:posList>
-                                        54.0 -12.0 54.0 -8.0 50.0 -8.0 50.0 -12.0 54.0 -12.0
-                                      </gml:posList>
-                                    </gml:LinearRing>
-                                  </gml:exterior>
-                                </gml:PolygonPatch>
-                              </gml:polygonPatches>
-                            </aixm:Surface>
-                          </aixm:horizontalProjection>
+                            <aixm:upperLimit uom="FL">390</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.e20caa4b-2b93-4d28-9b14-e04196314999" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <!-- bounding polygon clipped to edge of FIR @ 50N and 08W (in clockwise order) -->
+                                                    <gml:posList>
+                                                        54.0 -12.0 54.0 -8.0 50.0 -8.0 50.0 -12.0 54.0 -12.0
+                                                    </gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
-                      </iwxxm:geometry>
-                      <iwxxm:speedOfMotion uom="[kn_i]">20</iwxxm:speedOfMotion>
-                    </iwxxm:SIGMETEvolvingCondition>
-                  </iwxxm:member>
-                </iwxxm:SIGMETEvolvingConditionCollection>
-            </om:result>
-        </om:OM_Observation>
+                    </iwxxm:geometry>
+                    <iwxxm:speedOfMotion uom="[kn_i]">20</iwxxm:speedOfMotion>
+                </iwxxm:SIGMETEvolvingCondition>
+            </iwxxm:member>
+        </iwxxm:SIGMETEvolvingConditionCollection>
     </iwxxm:analysis>
 
 </iwxxm:SIGMET>

--- a/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
@@ -15,6 +15,13 @@
     permissibleUsage="OPERATIONAL"
     status="CANCELLATION">
 
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
+            <gml:timePosition>2012-08-10T13:45:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.e4f83cc7-2f15-441d-97dc-2ba9f3825a8e">
             <aixm:timeSlice>
@@ -43,7 +50,7 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
     
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
@@ -55,17 +62,10 @@
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
 
     <iwxxm:sequenceNumber>3</iwxxm:sequenceNumber>
   
-    <!-- time at which the results of the observation were made available (issued) -->
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
-            <gml:timePosition>2012-08-10T13:45:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
-
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.b1c68261-5b7d-4b39-9458-fbc92d8dc326">

--- a/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
@@ -7,13 +7,9 @@
 -->
 <iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.6fe37ba5-7ad5-471a-ac44-48ddefb2c23f"
     permissibleUsage="OPERATIONAL"
@@ -46,8 +42,29 @@
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
+    
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
+            <aixm:timeSlice>
+                <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:FIR_UIR</aixm:type>
+                    <aixm:designator>YUDD</aixm:designator>
+                    <aixm:name>SHANLON FIR/UIR</aixm:name>
+                </aixm:AirspaceTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
 
     <iwxxm:sequenceNumber>3</iwxxm:sequenceNumber>
+  
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
+            <gml:timePosition>2012-08-10T13:45:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
@@ -68,44 +85,5 @@
 
     <iwxxm:phenomenon nilReason="inapplicable"/>
 
-    <iwxxm:analysis>
-        <om:OM_Observation gml:id="uuid.7c75707a-b0e9-4784-b6d9-5218c055e8ca">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <om:phenomenonTime nilReason="inapplicable"/>
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.877a0733-fafb-4826-9afc-005c89a9dd3b">
-                    <gml:timePosition>2012-08-10T13:45:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <om:validTime xlink:href="#tp-20120810T1345Z-20120810T1600Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.05a38462-4063-466d-9010-413a085f3407">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.081f550e-29e2-42cb-8f9a-cb3f02c53d1f">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-                    <sf:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
-                            <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:type>OTHER:FIR_UIR</aixm:type>
-                                    <aixm:designator>YUDD</aixm:designator>
-                                    <aixm:name>SHANLON FIR/UIR</aixm:name>
-                                </aixm:AirspaceTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:Airspace>
-                    </sf:sampledFeature>
-                    <!-- FIR boundary - not typically reported -->
-                    <sams:shape nilReason="withheld"/>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result nilReason="inapplicable"/>
-        </om:OM_Observation>
-    </iwxxm:analysis>
-
+    <iwxxm:analysis nilReason="inapplicable"/>
 </iwxxm:SIGMET>

--- a/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
+++ b/3.0.0RC1/examples/sigmet-A6-1b-CNL.xml
@@ -5,11 +5,11 @@
       YUDD SIGMET 3 VALID 101345/101600 YUSO
       YUDD SHANLON FIR/UIR CNL SIGMET 2 101200/101600
 -->
-<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.6fe37ba5-7ad5-471a-ac44-48ddefb2c23f"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -13,6 +13,13 @@
     xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.f12194be-0d82-49ad-ad97-41e46f724dec" permissibleUsage="OPERATIONAL" status="NORMAL">
 
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.f598d1e0-8e2d-4af1-a4ee-83d04b37f19e">
+            <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.ee9eedf1-52d2-45b4-8f7c-f027dd25c5e6">
             <aixm:timeSlice>
@@ -40,7 +47,7 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.83b13711-6bf4-4497-9293-6bb5490bc259">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.44f4afb1-fab4-4d01-8030-7d51b43eb4ed">
@@ -53,17 +60,10 @@
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
 
 
     <iwxxm:sequenceNumber>3</iwxxm:sequenceNumber>
-
-    <!-- time at which the results of the observation were made available (issued) -->
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.f598d1e0-8e2d-4af1-a4ee-83d04b37f19e">
-            <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -6,11 +6,11 @@
       YUCC AMSWELL FIR TC GLORIA PSN N2706 W07306 CB OBS AT 1600Z WI 250NM OF TC CENTRE TOP FL500 NC
       FCST AT 2200Z TC CENTRE PSN N2740 W07345
 -->
-<iwxxm:TropicalCycloneSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:TropicalCycloneSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.f12194be-0d82-49ad-ad97-41e46f724dec" permissibleUsage="OPERATIONAL" status="NORMAL">
 
     <iwxxm:issuingAirTrafficServicesUnit>

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -8,17 +8,10 @@
 -->
 <iwxxm:TropicalCycloneSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-
-    gml:id="uuid.f12194be-0d82-49ad-ad97-41e46f724dec"
-    permissibleUsage="OPERATIONAL"
-    status="NORMAL">
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    gml:id="uuid.f12194be-0d82-49ad-ad97-41e46f724dec" permissibleUsage="OPERATIONAL" status="NORMAL">
 
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.ee9eedf1-52d2-45b4-8f7c-f027dd25c5e6">
@@ -47,7 +40,30 @@
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
 
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.83b13711-6bf4-4497-9293-6bb5490bc259">
+            <aixm:timeSlice>
+                <aixm:AirspaceTimeSlice gml:id="uuid.44f4afb1-fab4-4d01-8030-7d51b43eb4ed">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>FIR</aixm:type>
+                    <aixm:designator>YUCC</aixm:designator>
+                    <aixm:name>AMSWELL FIR</aixm:name>
+                </aixm:AirspaceTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
+
+    <!-- FIR boundary not typically reported -->
+
     <iwxxm:sequenceNumber>3</iwxxm:sequenceNumber>
+
+    <!-- time at which the results of the observation were made available (issued) -->
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.f598d1e0-8e2d-4af1-a4ee-83d04b37f19e">
+            <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
     <!-- Valid period for this report -->
     <iwxxm:validPeriod>
@@ -62,148 +78,92 @@
 
     <!-- OBS AT 1600Z -->
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="uuid.4cd84f41-edbf-4dc6-ba67-88048d9d1368">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
+        <!-- CB OBS AT 1600Z WI 250NM OF TC CENTRE TOP FL500 NC -->
+        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.89147e42-7ce0-493e-b81d-6ba6a989e8a1" timeIndicator="OBSERVATION">
             <!-- time of observed conditions -->
-            <om:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.2f6d2369-b614-4522-8c76-bc44d770ce5e">
                     <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.f598d1e0-8e2d-4af1-a4ee-83d04b37f19e">
-                    <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <!-- The valid period for this observation is the period of the entire SIGMET -->
-            <om:validTime xlink:href="#tp-20120825T1600Z-20120825T2200Z"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.7cb644bf-d7d8-4842-803e-84cc4de4e8f0">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 6-1 TECHNICAL SPECIFICATIONS RELATED TO SIGMET INFORMATION</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <!-- featureOfInterest type and shape MUST refer to an SF_SamplingSurface -->
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.8eb74801-27b9-4e74-8704-5bfa18ded253">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-                    <sf:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.83b13711-6bf4-4497-9293-6bb5490bc259">
-                            <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="uuid.44f4afb1-fab4-4d01-8030-7d51b43eb4ed">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:type>FIR</aixm:type>
-                                    <aixm:designator>YUCC</aixm:designator>
-                                    <aixm:name>AMSWELL FIR</aixm:name>
-                                </aixm:AirspaceTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:Airspace>
-                    </sf:sampledFeature>
-                    <!-- FIR boundary - not typically reported -->
-                    <sams:shape nilReason="withheld"/>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <!-- CB OBS AT 1600Z WI 250NM OF TC CENTRE TOP FL500 NC -->
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.89147e42-7ce0-493e-b81d-6ba6a989e8a1" timeIndicator="OBSERVATION">
-                  <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.c0a23437-9eb7-4e6b-82f2-6fbd5757440c" intensityChange="NO_CHANGE">
-                      <!-- This shape describes:
-                          N2706 W07306 CB TOP FL500 WI 150NM OF CENTRE i.e., a 150NM radius around -73.10 (lon), 27.10 (lat) -->
-                      <iwxxm:geometry>
-                          <aixm:AirspaceVolume gml:id="uuid.08077323-fbd5-4e04-a787-fccff0543f0a">
-                              <aixm:upperLimit uom="FL">500</aixm:upperLimit>
-                              <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                              <aixm:horizontalProjection>
-                                  <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                      <gml:polygonPatches>
-                                          <gml:PolygonPatch>
-                                              <gml:exterior>
-                                                  <gml:Ring>
-                                                      <gml:curveMember>
-                                                          <gml:Curve gml:id="uuid.b7fa4047-2e78-431c-ba95-3fdf6343e3b5">
-                                                              <gml:segments>
-                                                                  <gml:CircleByCenterPoint numArc="1">
-                                                                      <gml:pos>27.10 -73.10</gml:pos>
-                                                                      <gml:radius uom="[nmi_i]">250</gml:radius>
-                                                                  </gml:CircleByCenterPoint>
-                                                              </gml:segments>
-                                                          </gml:Curve>
-                                                      </gml:curveMember>
-                                                  </gml:Ring>
-                                              </gml:exterior>
-                                          </gml:PolygonPatch>
-                                      </gml:polygonPatches>
-                                  </aixm:Surface>
-                              </aixm:horizontalProjection>
-                          </aixm:AirspaceVolume>
-                      </iwxxm:geometry>
-                    </iwxxm:SIGMETEvolvingCondition>
-                  </iwxxm:member>
-                </iwxxm:SIGMETEvolvingConditionCollection>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:member>
+                <iwxxm:SIGMETEvolvingCondition gml:id="uuid.c0a23437-9eb7-4e6b-82f2-6fbd5757440c" intensityChange="NO_CHANGE">
+                    <!-- This shape describes:
+                        N2706 W07306 CB TOP FL500 WI 150NM OF CENTRE i.e., a 150NM radius around -73.10 (lon), 27.10 (lat) -->
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.08077323-fbd5-4e04-a787-fccff0543f0a">
+                            <aixm:upperLimit uom="FL">500</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:Ring>
+                                                    <gml:curveMember>
+                                                        <gml:Curve gml:id="uuid.b7fa4047-2e78-431c-ba95-3fdf6343e3b5">
+                                                            <gml:segments>
+                                                                <gml:CircleByCenterPoint numArc="1">
+                                                                    <gml:pos>27.10 -73.10</gml:pos>
+                                                                    <gml:radius uom="[nmi_i]">250</gml:radius>
+                                                                </gml:CircleByCenterPoint>
+                                                            </gml:segments>
+                                                        </gml:Curve>
+                                                    </gml:curveMember>
+                                                </gml:Ring>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETEvolvingCondition>
+            </iwxxm:member>
+        </iwxxm:SIGMETEvolvingConditionCollection>
     </iwxxm:analysis>
 
     <!-- FCST AT 2200Z TC CENTRE PSN N2740 W07345 -->
     <iwxxm:forecastPositionAnalysis>
-        <om:OM_Observation gml:id="uuid.caee76a0-bb11-48d3-b1cb-d916302dc81d">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
+        <iwxxm:SIGMETPositionCollection gml:id="uuid.59824907-bcbe-476d-8151-8743e4a1b7db">
             <!-- time of forecast conditions -->
-            <om:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.aab0df0d-6ee9-4ff8-82b2-06a2a42ab0a9">
                     <gml:timePosition>2012-08-25T22:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.b76d57ea-3648-4d91-8d71-6b627424b16c">
-                    <gml:timePosition>2012-08-25T16:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <!-- The valid period for this observation is the period of the entire SIGMET -->
-            <om:validTime xlink:href="#tp-20120825T1600Z-20120825T2200Z"/>
-            <om:procedure xlink:href="#p-49-2-sigmet"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
-            <om:featureOfInterest xlink:href="#sampling-surface-Amswell"/>
-            <om:result>
-                <iwxxm:SIGMETPositionCollection gml:id="uuid.59824907-bcbe-476d-8151-8743e4a1b7db">
-                    <iwxxm:member>
-                        <!-- TC CENTRE N2740 W07345 -->
-                        <iwxxm:SIGMETPosition gml:id="uuid.338354de-7634-4fca-ac75-3675cb592284">
-                            <iwxxm:geometry>
-                                <aixm:AirspaceVolume gml:id="uuid.4ed35f91-7189-4b9c-baed-19b5cec0b4c1">
-                                    <aixm:horizontalProjection>
-                                        <aixm:Surface gml:id="uuid.c76ff9fa-ec6b-48ed-8f26-ed37c47bbc38" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
-                                                <gml:PolygonPatch>
-                                                    <gml:exterior>
-                                                        <gml:Ring>
-                                                            <gml:curveMember>
-                                                                <gml:Curve gml:id="uuid.0380d35a-1d35-46a2-bbc8-38190206bfe8">
-                                                                    <gml:segments>
-                                                                        <gml:CircleByCenterPoint numArc="1">
-                                                                            <gml:pos>27.6667 -73.75</gml:pos>
-                                                                            <gml:radius uom="[nmi_i]">0</gml:radius>
-                                                                        </gml:CircleByCenterPoint>
-                                                                    </gml:segments>
-                                                                </gml:Curve>
-                                                            </gml:curveMember>
-                                                        </gml:Ring>
-                                                    </gml:exterior>
-                                                </gml:PolygonPatch>
-                                            </gml:polygonPatches>
-                                        </aixm:Surface>
-                                    </aixm:horizontalProjection>
-                                </aixm:AirspaceVolume>
-                            </iwxxm:geometry>
-                        </iwxxm:SIGMETPosition>
-                    </iwxxm:member>
-                </iwxxm:SIGMETPositionCollection>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:member>
+                <!-- TC CENTRE N2740 W07345 -->
+                <iwxxm:SIGMETPosition gml:id="uuid.338354de-7634-4fca-ac75-3675cb592284">
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.4ed35f91-7189-4b9c-baed-19b5cec0b4c1">
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.c76ff9fa-ec6b-48ed-8f26-ed37c47bbc38" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:Ring>
+                                                    <gml:curveMember>
+                                                        <gml:Curve gml:id="uuid.0380d35a-1d35-46a2-bbc8-38190206bfe8">
+                                                            <gml:segments>
+                                                                <gml:CircleByCenterPoint numArc="1">
+                                                                    <gml:pos>27.6667 -73.75</gml:pos>
+                                                                    <gml:radius uom="[nmi_i]">0</gml:radius>
+                                                                </gml:CircleByCenterPoint>
+                                                            </gml:segments>
+                                                        </gml:Curve>
+                                                    </gml:curveMember>
+                                                </gml:Ring>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETPosition>
+            </iwxxm:member>
+        </iwxxm:SIGMETPositionCollection>
     </iwxxm:forecastPositionAnalysis>
 
     <iwxxm:tropicalCyclone>

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -49,12 +49,12 @@
                     <aixm:type>FIR</aixm:type>
                     <aixm:designator>YUCC</aixm:designator>
                     <aixm:name>AMSWELL FIR</aixm:name>
+                    <!-- FIR boundary can be reported in an aixm:geometryComponent -->
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
     </iwxxm:flightInformationRegion>
 
-    <!-- FIR boundary not typically reported -->
 
     <iwxxm:sequenceNumber>3</iwxxm:sequenceNumber>
 

--- a/3.0.0RC1/examples/sigmet-VA-EGGX.xml
+++ b/3.0.0RC1/examples/sigmet-VA-EGGX.xml
@@ -4,13 +4,13 @@ EGGX SIGMET 4 VALID 251600/252200 EGRR -
 EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 1600Z SFC/FL550 N6000 W01150 - N5900 W01300 - N6000 W01600 - N6000 W01150 MOV S 60KT NC FCST 2200Z SFC/FL550 N6000 W01200 - N5800 W01400 - N6000 W01535 - N6000 W01200
 -->
 <!-- note: year and month of this SIGMET unknown; YYYY and MM used in place of actual values -->
-<iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.64c3912b-b09a-494a-8731-321f28b759e4"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">

--- a/3.0.0RC1/examples/sigmet-VA-EGGX.xml
+++ b/3.0.0RC1/examples/sigmet-VA-EGGX.xml
@@ -7,16 +7,10 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
 <iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:om="http://www.opengis.net/om/2.0"
-    xmlns:sam="http://www.opengis.net/sampling/2.0"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.64c3912b-b09a-494a-8731-321f28b759e4"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
@@ -46,7 +40,25 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.1fa42185-604c-4a56-a578-d1eb07109c38">
+            <aixm:timeSlice>
+                <aixm:AirspaceTimeSlice gml:id="uuid.df98083d-660a-45be-9292-8037b13da46c">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>FIR</aixm:type>
+                    <aixm:designator>EGGX</aixm:designator>
+                    <aixm:name>SHANWICK OCEANIC FIR</aixm:name>
+                </aixm:AirspaceTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
     <iwxxm:sequenceNumber>4</iwxxm:sequenceNumber>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.94838606-4ec4-437c-9be1-901b8e7a33c6">
+            <gml:timePosition>YYYY-MM-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.099bfa3a-0fb2-4a79-87f5-076fa28e6711">
             <gml:beginPosition>YYYY-MM-25T16:00:00Z</gml:beginPosition>
@@ -55,128 +67,85 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
     </iwxxm:validPeriod>
     <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SigWxPhenomena/VA"/>
     <iwxxm:analysis>
-        <om:OM_Observation gml:id="uuid.94838606-4ec4-437c-9be1-901b8e7a33c6">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <om:phenomenonTime>
+        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.fb90468d-60bb-4828-99ed-3ff730759ac3" timeIndicator="OBSERVATION">
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.0fff6dbb-ba23-4794-810e-d2b79c895053">
                     <gml:timePosition>YYYY-MM-25T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-            <om:resultTime xlink:href="#ti-25T16Z"/>
-	    <om:validTime xlink:href="#tp-25T16Z-25T22Z"/>
-	    <om:procedure>
-                <metce:Process gml:id="uuid.73b043ca-bb18-446b-9118-2577d1422dcb">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation [C.3.1.]7 SIGMET AND AIRMET INFORMATION, AERODROME WARNINGS AND WIND SHEAR WARNINGS AND ALERTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
-            <om:featureOfInterest>
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.9b1c2b6f-33ac-46d7-9c91-d85d50d84063">
-                    <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-                    <sam:sampledFeature>
-                        <aixm:Airspace gml:id="uuid.1fa42185-604c-4a56-a578-d1eb07109c38">
-                            <aixm:timeSlice>
-                                <aixm:AirspaceTimeSlice gml:id="uuid.df98083d-660a-45be-9292-8037b13da46c">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:type>FIR</aixm:type>
-                                    <aixm:designator>EGGX</aixm:designator>
-                                    <aixm:name>SHANWICK OCEANIC FIR</aixm:name>
-                                </aixm:AirspaceTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:Airspace>
-                    </sam:sampledFeature>
-                    <!-- FIR boundary - not typically reported -->
-                    <sams:shape nilReason="withheld"/>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.fb90468d-60bb-4828-99ed-3ff730759ac3" timeIndicator="OBSERVATION">
-                  <iwxxm:member>
-                    <iwxxm:SIGMETEvolvingCondition gml:id="uuid.b3f301d8-e8b4-4d24-91b1-78f52672edcb" intensityChange="NO_CHANGE">
-                      <iwxxm:directionOfMotion uom="deg">180</iwxxm:directionOfMotion>
-                      <iwxxm:geometry>
-                        <aixm:AirspaceVolume gml:id="uuid.6a77deae-62d5-43c0-99df-c40a6ddf4e3f">
-                          <!-- omitted lower-limit implies that the volcanic ash cloud extends to ground/sea surface -->
-                          <aixm:upperLimit uom="FL">550</aixm:upperLimit>
-                          <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                          <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="uuid.99f0ea38-755d-4435-b7c7-7cc5afcce237"
-                              uomLabels="deg deg"
-                              axisLabels="Lat Lon"
-                              srsDimension="2"
-                              srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                              <gml:polygonPatches>
-                                <gml:PolygonPatch>
-                                  <gml:exterior>
-                                    <gml:LinearRing>
-                                      <!-- bounding polygon clipped to edge of FIR @ 60N -->
-                                      <gml:posList>
-                                        60.0 -11.5
-                                        59.0 -13.0
-                                        60.0 -16.0
-                                        60.0 -11.5
-                                      </gml:posList>
-                                    </gml:LinearRing>
-                                  </gml:exterior>
-                                </gml:PolygonPatch>
-                              </gml:polygonPatches>
-                            </aixm:Surface>
-                          </aixm:horizontalProjection>
-                        </aixm:AirspaceVolume>
-                      </iwxxm:geometry>
-                      <iwxxm:speedOfMotion uom="[kn_i]">60</iwxxm:speedOfMotion>
-                    </iwxxm:SIGMETEvolvingCondition>
-                  </iwxxm:member>
-                </iwxxm:SIGMETEvolvingConditionCollection>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:member>
+                <iwxxm:SIGMETEvolvingCondition gml:id="uuid.b3f301d8-e8b4-4d24-91b1-78f52672edcb" intensityChange="NO_CHANGE">
+                  <iwxxm:directionOfMotion uom="deg">180</iwxxm:directionOfMotion>
+                  <iwxxm:geometry>
+                    <aixm:AirspaceVolume gml:id="uuid.6a77deae-62d5-43c0-99df-c40a6ddf4e3f">
+                      <!-- omitted lower-limit implies that the volcanic ash cloud extends to ground/sea surface -->
+                      <aixm:upperLimit uom="FL">550</aixm:upperLimit>
+                      <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                      <aixm:horizontalProjection>
+                        <aixm:Surface gml:id="uuid.99f0ea38-755d-4435-b7c7-7cc5afcce237"
+                          uomLabels="deg deg"
+                          axisLabels="Lat Lon"
+                          srsDimension="2"
+                          srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                          <gml:polygonPatches>
+                            <gml:PolygonPatch>
+                              <gml:exterior>
+                                <gml:LinearRing>
+                                  <!-- bounding polygon clipped to edge of FIR @ 60N -->
+                                  <gml:posList>
+                                    60.0 -11.5
+                                    59.0 -13.0
+                                    60.0 -16.0
+                                    60.0 -11.5
+                                  </gml:posList>
+                                </gml:LinearRing>
+                              </gml:exterior>
+                            </gml:PolygonPatch>
+                          </gml:polygonPatches>
+                        </aixm:Surface>
+                      </aixm:horizontalProjection>
+                    </aixm:AirspaceVolume>
+                  </iwxxm:geometry>
+                  <iwxxm:speedOfMotion uom="[kn_i]">60</iwxxm:speedOfMotion>
+                </iwxxm:SIGMETEvolvingCondition>
+          </iwxxm:member>
+        </iwxxm:SIGMETEvolvingConditionCollection>
     </iwxxm:analysis>
     <iwxxm:forecastPositionAnalysis>
-        <om:OM_Observation gml:id="uuid.cc6dcc03-dc8a-4185-b36b-b3282e07fbdf">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
-            <om:phenomenonTime>
+        <iwxxm:SIGMETPositionCollection gml:id="uuid.a76bad9a-9d0b-45ea-82ed-c5f697b9d68a">
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.8176a547-141d-471f-b12f-10b7338dadbe">
                     <gml:timePosition>YYYY-MM-25T22:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-            <om:resultTime xlink:href="#ti-25T16Z"/>
-            <om:validTime xlink:href="#tp-25T16Z-25T22Z"/>
-            <om:procedure xlink:href="#p-49-2-va-sigmet"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
-            <om:featureOfInterest xlink:href="#ss-SHANWICK_OCA"/>
-            <om:result>
-                <iwxxm:SIGMETPositionCollection gml:id="uuid.a76bad9a-9d0b-45ea-82ed-c5f697b9d68a">
-                    <iwxxm:member>
-                        <iwxxm:SIGMETPosition gml:id="uuid.fefac6d8-d236-4008-ad4d-cc8b229b7c50">
-                            <iwxxm:geometry>
-                                <aixm:AirspaceVolume gml:id="uuid.e985f12a-5e11-433c-aa5e-699eecb0c244">
-                                    <aixm:horizontalProjection>
-                                        <aixm:Surface gml:id="uuid.a667da6f-fb8a-4029-93f3-509ab9408220" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
-                                                <gml:PolygonPatch>
-                                                    <gml:exterior>
-                                                        <gml:LinearRing>
-                                                            <!-- bounding polygon clipped to edge of FIR @ 60N -->
-                                                            <gml:posList>
-                                                                60.0 -12.0
-                                                                58.0 -14.0
-                                                                60.0 -15.35
-                                                                60.0 -12.0
-                                                            </gml:posList>
-                                                        </gml:LinearRing>
-                                                    </gml:exterior>
-                                                </gml:PolygonPatch>
-                                            </gml:polygonPatches>
-                                        </aixm:Surface>
-                                    </aixm:horizontalProjection>
-                                </aixm:AirspaceVolume>
-                            </iwxxm:geometry>
-                        </iwxxm:SIGMETPosition>
-                    </iwxxm:member>
-                </iwxxm:SIGMETPositionCollection>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:member>
+                <iwxxm:SIGMETPosition gml:id="uuid.fefac6d8-d236-4008-ad4d-cc8b229b7c50">
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.e985f12a-5e11-433c-aa5e-699eecb0c244">
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.a667da6f-fb8a-4029-93f3-509ab9408220" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <!-- bounding polygon clipped to edge of FIR @ 60N -->
+                                                    <gml:posList>
+                                                        60.0 -12.0
+                                                        58.0 -14.0
+                                                        60.0 -15.35
+                                                        60.0 -12.0
+                                                    </gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETPosition>
+            </iwxxm:member>
+        </iwxxm:SIGMETPositionCollection>
     </iwxxm:forecastPositionAnalysis>
     <iwxxm:eruptingVolcano>
         <metce:Volcano gml:id="uuid.99646618-9ec7-47c0-8b50-daba5b6b1da9">

--- a/3.0.0RC1/examples/sigmet-VA-EGGX.xml
+++ b/3.0.0RC1/examples/sigmet-VA-EGGX.xml
@@ -49,6 +49,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                     <aixm:type>FIR</aixm:type>
                     <aixm:designator>EGGX</aixm:designator>
                     <aixm:name>SHANWICK OCEANIC FIR</aixm:name>
+                    <!-- FIR boundary can be reported in an aixm:geometryComponent -->
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>

--- a/3.0.0RC1/examples/sigmet-VA-EGGX.xml
+++ b/3.0.0RC1/examples/sigmet-VA-EGGX.xml
@@ -14,6 +14,11 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
     gml:id="uuid.64c3912b-b09a-494a-8731-321f28b759e4"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.94838606-4ec4-437c-9be1-901b8e7a33c6">
+            <gml:timePosition>YYYY-MM-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.cdca7fc8-2ca0-42fd-b335-822e3f8c7921">
             <aixm:timeSlice>
@@ -40,7 +45,7 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.1fa42185-604c-4a56-a578-d1eb07109c38">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.df98083d-660a-45be-9292-8037b13da46c">
@@ -53,13 +58,8 @@ EGGX SHANWICK OCEANIC FIR VA ERUPTION MT HEKLA PSN N6359 W01940 VA CLD OBS AT 16
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
     <iwxxm:sequenceNumber>4</iwxxm:sequenceNumber>
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.94838606-4ec4-437c-9be1-901b8e7a33c6">
-            <gml:timePosition>YYYY-MM-25T16:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.099bfa3a-0fb2-4a79-87f5-076fa28e6711">
             <gml:beginPosition>YYYY-MM-25T16:00:00Z</gml:beginPosition>

--- a/3.0.0RC1/examples/sigmet-multi-location.xml
+++ b/3.0.0RC1/examples/sigmet-multi-location.xml
@@ -19,6 +19,11 @@
     gml:id="uuid.b4d56d93-3866-4f75-b493-da9a4bb2404c"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
+            <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
     <iwxxm:issuingAirTrafficServicesUnit>
         <aixm:Unit gml:id="uuid.37f89b19-7774-496b-a20d-f30627c45d17">
             <aixm:timeSlice>
@@ -45,7 +50,7 @@
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:originatingMeteorologicalWatchOffice>
-    <iwxxm:flightInformationRegion>
+    <iwxxm:issuingAirTrafficServicesRegion>
         <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
             <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
@@ -58,13 +63,8 @@
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>
-    </iwxxm:flightInformationRegion>
+    </iwxxm:issuingAirTrafficServicesRegion>
     <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
-            <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
     <iwxxm:validPeriod>
         <gml:TimePeriod gml:id="uuid.06f1383c-c034-4ae0-9459-a0b99a3612a9">
             <gml:beginPosition>YYYY-MM-10T12:00:00Z</gml:beginPosition>

--- a/3.0.0RC1/examples/sigmet-multi-location.xml
+++ b/3.0.0RC1/examples/sigmet-multi-location.xml
@@ -10,225 +10,196 @@
       FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E02130 - N4200 E02145=
 -->
 <iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
-  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-  xmlns:metce="http://def.wmo.int/metce/2013"
-  xmlns:om="http://www.opengis.net/om/2.0"
-  xmlns:sam="http://www.opengis.net/sampling/2.0"
-  xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-  xmlns:gml="http://www.opengis.net/gml/3.2"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-  http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-  http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="uuid.b4d56d93-3866-4f75-b493-da9a4bb2404c"
-  permissibleUsage="OPERATIONAL"
-  status="NORMAL">
-  <iwxxm:issuingAirTrafficServicesUnit>
-    <aixm:Unit gml:id="uuid.37f89b19-7774-496b-a20d-f30627c45d17">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.c01e968b-77b1-4cfd-aedb-50d37f09c345">
-          <gml:validTime/>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>SHANWICK OCEANIC AREA CONTROL CENTRE</aixm:name>
-          <aixm:type>ATCC</aixm:type>
-          <aixm:designator>YUDD</aixm:designator>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:issuingAirTrafficServicesUnit>
-  <iwxxm:originatingMeteorologicalWatchOffice>
-    <aixm:Unit gml:id="uuid.252469f5-d46a-41b4-a932-87e37328c474">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.58703e69-de03-41b8-b18c-9209e37aff94">
-          <gml:validTime/>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>UK METEOROLOGICAL OFFICE - EXETER</aixm:name>
-          <aixm:type>MWO</aixm:type>
-          <aixm:designator>YUSO</aixm:designator>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:originatingMeteorologicalWatchOffice>
-  <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
-  <iwxxm:validPeriod>
-    <gml:TimePeriod gml:id="uuid.06f1383c-c034-4ae0-9459-a0b99a3612a9">
-      <gml:beginPosition>YYYY-MM-10T12:00:00Z</gml:beginPosition>
-      <gml:endPosition>YYYY-MM-10T18:00:00Z</gml:endPosition>
-    </gml:TimePeriod>
-  </iwxxm:validPeriod>
-  <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SigWxPhenomena/VA"/>
-  <!-- VA CLD OBS AT 1200Z WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC
-                       AND WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
-  <iwxxm:analysis>
-    <om:OM_Observation gml:id="uuid.be132ece-3217-4448-866d-d47feeb7914d">
-      <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETEvolvingConditionCollectionAnalysis"/>
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
-          <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:phenomenonTime>
-      <om:resultTime xlink:href="#ti-10T12Z"/>
-      <om:validTime xlink:href="#tp-10T12Z-10T22Z"/>
-      <om:procedure>
-        <metce:Process gml:id="uuid.44a28548-e50b-44dd-93a2-acb32843dc8e">
-          <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation [C.3.1.]7 SIGMET AND AIRMET INFORMATION, AERODROME WARNINGS AND WIND SHEAR WARNINGS AND ALERTS</gml:description>
-        </metce:Process>
-      </om:procedure>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETEvolvingConditionCollectionAnalysis"/>
-      <om:featureOfInterest>
-        <sams:SF_SpatialSamplingFeature gml:id="uuid.066936d2-7d12-4447-9feb-b74fe3069490">
-          <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-          <sam:sampledFeature>
-            <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
-              <aixm:timeSlice>
+    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+    xmlns:metce="http://def.wmo.int/metce/2013"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    gml:id="uuid.b4d56d93-3866-4f75-b493-da9a4bb2404c"
+    permissibleUsage="OPERATIONAL"
+    status="NORMAL">
+    <iwxxm:issuingAirTrafficServicesUnit>
+        <aixm:Unit gml:id="uuid.37f89b19-7774-496b-a20d-f30627c45d17">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.c01e968b-77b1-4cfd-aedb-50d37f09c345">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:name>SHANWICK OCEANIC AREA CONTROL CENTRE</aixm:name>
+                    <aixm:type>ATCC</aixm:type>
+                    <aixm:designator>YUDD</aixm:designator>
+                </aixm:UnitTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Unit>
+    </iwxxm:issuingAirTrafficServicesUnit>
+    <iwxxm:originatingMeteorologicalWatchOffice>
+        <aixm:Unit gml:id="uuid.252469f5-d46a-41b4-a932-87e37328c474">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.58703e69-de03-41b8-b18c-9209e37aff94">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:name>UK METEOROLOGICAL OFFICE - EXETER</aixm:name>
+                    <aixm:type>MWO</aixm:type>
+                    <aixm:designator>YUSO</aixm:designator>
+                </aixm:UnitTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Unit>
+    </iwxxm:originatingMeteorologicalWatchOffice>
+    <iwxxm:flightInformationRegion>
+        <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
+            <aixm:timeSlice>
                 <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
-                  <gml:validTime/>
-                  <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                  <aixm:type>OTHER:FIR_UIR</aixm:type>
-                  <aixm:designator>YUDD</aixm:designator>
-                  <aixm:name>SHANLON FIR/UIR</aixm:name>
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:FIR_UIR</aixm:type>
+                    <aixm:designator>YUDD</aixm:designator>
+                    <aixm:name>SHANLON FIR/UIR</aixm:name>
                 </aixm:AirspaceTimeSlice>
-              </aixm:timeSlice>
-            </aixm:Airspace>
-          </sam:sampledFeature>
-          <!-- FIR boundary - not typically reported -->
-          <sams:shape nilReason="withheld"/>
-        </sams:SF_SpatialSamplingFeature>
-      </om:featureOfInterest>
-      <om:result>
-        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.ed862622-5643-4c5a-8922-01a04d18dbab" timeIndicator="OBSERVATION">
-          <!-- WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC -->
-          <iwxxm:member>
-            <iwxxm:SIGMETEvolvingCondition gml:id="uuid.6cad5163-6a30-48a0-b723-2a14b5a93cc8" intensityChange="NO_CHANGE">
-              <!-- N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 -->
-              <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="uuid.8f3df57f-54a0-40dc-8c2d-b9cfe15f68fa">
-                  <aixm:upperLimit uom="FL">370</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.ca46d217-05d8-4f30-9ce0-b56b76af8d16" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
-                      srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>43.15 21.15 43.45 21.45 43.30 22.15 42.45 22.30 42.30 21.45 43.15 21.15</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:polygonPatches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:geometry>
-            </iwxxm:SIGMETEvolvingCondition>
-          </iwxxm:member>
-          <!-- WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
-          <iwxxm:member>
-            <iwxxm:SIGMETEvolvingCondition gml:id="uuid.2425da44-f643-45c8-972c-ff122f50de80" intensityChange="NO_CHANGE">
-              <!-- N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 -->
-              <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="uuid.99d24aa8-6778-4356-be69-e91e529836ab">
-                  <aixm:upperLimit uom="FL">300</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit uom="FL">150</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.4a5d7c8d-9ab3-402a-86ff-3889823df192" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
-                      srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>42.00 21.15 42.17 21.30 41.45 22.00 41.30 21.30 42.00 21.15</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:polygonPatches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:geometry>
-            </iwxxm:SIGMETEvolvingCondition>
-          </iwxxm:member>
-        </iwxxm:SIGMETEvolvingConditionCollection>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:analysis>
-  <iwxxm:forecastPositionAnalysis>
-    <om:OM_Observation gml:id="uuid.ee97301b-9177-4241-87eb-34c239621973">
-      <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/SIGMETPositionCollectionAnalysis"/>
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.cce9b23a-d604-4194-8f73-2b7357ee4a9c">
-          <gml:timePosition>YYYY-MM-10T18:00:00Z</gml:timePosition>
+            </aixm:timeSlice>
+        </aixm:Airspace>
+    </iwxxm:flightInformationRegion>
+    <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
+            <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
         </gml:TimeInstant>
-      </om:phenomenonTime>
-      <om:resultTime xlink:href="#ti-10T12Z"/>
-      <om:validTime xlink:href="#tp-10T12Z-10T22Z"/>
-      <om:procedure xlink:href="#p-49-2-va-sigmet"/>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/SIGMETPositionCollectionAnalysis"/>
-      <om:featureOfInterest xlink:href="#ss-SHANWICK_OCA"/>
-      <om:result>
+    </iwxxm:issueTime>
+    <iwxxm:validPeriod>
+        <gml:TimePeriod gml:id="uuid.06f1383c-c034-4ae0-9459-a0b99a3612a9">
+            <gml:beginPosition>YYYY-MM-10T12:00:00Z</gml:beginPosition>
+            <gml:endPosition>YYYY-MM-10T18:00:00Z</gml:endPosition>
+        </gml:TimePeriod>
+    </iwxxm:validPeriod>
+    <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SigWxPhenomena/VA"/>
+    <!-- VA CLD OBS AT 1200Z WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC
+                       AND WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
+    <iwxxm:analysis>
+        <iwxxm:SIGMETEvolvingConditionCollection gml:id="uuid.ed862622-5643-4c5a-8922-01a04d18dbab" timeIndicator="OBSERVATION">
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.5299e948-f719-4fd2-85fc-20ad96644250">
+                    <gml:timePosition>YYYY-MM-10T12:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+
+            <!-- WI N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 NC -->
+            <iwxxm:member>
+                <iwxxm:SIGMETEvolvingCondition gml:id="uuid.6cad5163-6a30-48a0-b723-2a14b5a93cc8" intensityChange="NO_CHANGE">
+                    <!-- N4315 E02115 – N4345 E02145 N4330 E02215 – N4245 E02230 – N4230 E02145 - N4315 E02115 FL250/370 -->
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.8f3df57f-54a0-40dc-8c2d-b9cfe15f68fa">
+                            <aixm:upperLimit uom="FL">370</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.ca46d217-05d8-4f30-9ce0-b56b76af8d16" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
+                                    srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>43.15 21.15 43.45 21.45 43.30 22.15 42.45 22.30 42.30 21.45 43.15 21.15</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETEvolvingCondition>
+            </iwxxm:member>
+            <!-- WI N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 NC -->
+            <iwxxm:member>
+                <iwxxm:SIGMETEvolvingCondition gml:id="uuid.2425da44-f643-45c8-972c-ff122f50de80" intensityChange="NO_CHANGE">
+                    <!-- N4200 E02115 – N4217 E02130 – N4145 E02200 – N4130 E02130 – N4200 E02115 FL150/300 -->
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.99d24aa8-6778-4356-be69-e91e529836ab">
+                            <aixm:upperLimit uom="FL">300</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit uom="FL">150</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.4a5d7c8d-9ab3-402a-86ff-3889823df192" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2"
+                                    srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>42.00 21.15 42.17 21.30 41.45 22.00 41.30 21.30 42.00 21.15</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETEvolvingCondition>
+            </iwxxm:member>
+        </iwxxm:SIGMETEvolvingConditionCollection>
+    </iwxxm:analysis>
+    <iwxxm:forecastPositionAnalysis>
         <iwxxm:SIGMETPositionCollection gml:id="uuid.fad0d2b4-7b60-4843-b17c-501f7b13efe0">
-          <!-- APRX N4330 E02215 – N4315 E02345 – N4145 E02315 – N4230 E02200 - N4330 E02215 -->
-          <iwxxm:member>
-            <iwxxm:SIGMETPosition gml:id="uuid.a229e75e-9c12-4bac-a4d3-37eeaa99023f" approximateLocation="true">
-              <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="uuid.908afad2-34ae-49bf-8f7a-866961c781f1">
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.c5464381-23a9-4641-8a79-df05e394302e" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>43.30 22.15 43.15 23.45 41.45 23.15 42.30 22.00 43.30 22.15</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:polygonPatches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:geometry>
-            </iwxxm:SIGMETPosition>
-          </iwxxm:member>
-          <!-- APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E02130 - N4200 E02145 -->
-          <iwxxm:member>
-            <iwxxm:SIGMETPosition gml:id="uuid.43b58951-4023-4805-97f3-bad21c4e6f74"  approximateLocation="true">
-              <iwxxm:geometry>
-                <aixm:AirspaceVolume gml:id="uuid.c8c2ee62-3075-4642-89b9-8a84f28e510a">
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.c772f1bd-7684-4572-9907-7c742cc2013a" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:polygonPatches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>42.00 21.45 41.45 22.15 41.00 22.15 41.30 21.30 42.00 21.45</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:polygonPatches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:geometry>
-            </iwxxm:SIGMETPosition>
-          </iwxxm:member>
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.cce9b23a-d604-4194-8f73-2b7357ee4a9c">
+                    <gml:timePosition>YYYY-MM-10T18:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <!-- APRX N4330 E02215 – N4315 E02345 – N4145 E02315 – N4230 E02200 - N4330 E02215 -->
+            <iwxxm:member>
+                <iwxxm:SIGMETPosition gml:id="uuid.a229e75e-9c12-4bac-a4d3-37eeaa99023f" approximateLocation="true">
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.908afad2-34ae-49bf-8f7a-866961c781f1">
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.c5464381-23a9-4641-8a79-df05e394302e" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>43.30 22.15 43.15 23.45 41.45 23.15 42.30 22.00 43.30 22.15</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETPosition>
+            </iwxxm:member>
+            <!-- APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E02130 - N4200 E02145 -->
+            <iwxxm:member>
+                <iwxxm:SIGMETPosition gml:id="uuid.43b58951-4023-4805-97f3-bad21c4e6f74" approximateLocation="true">
+                    <iwxxm:geometry>
+                        <aixm:AirspaceVolume gml:id="uuid.c8c2ee62-3075-4642-89b9-8a84f28e510a">
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.c772f1bd-7684-4572-9907-7c742cc2013a" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                                    <gml:polygonPatches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>42.00 21.45 41.45 22.15 41.00 22.15 41.30 21.30 42.00 21.45</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:polygonPatches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:geometry>
+                </iwxxm:SIGMETPosition>
+            </iwxxm:member>
         </iwxxm:SIGMETPositionCollection>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:forecastPositionAnalysis>
-  <iwxxm:eruptingVolcano>
-    <metce:Volcano gml:id="uuid.8c2bf282-1268-4066-bfc9-a56f7ae999f5">
-      <metce:name>MT ASHVAL</metce:name>
-      <metce:position>
-        <gml:Point gml:id="uuid.2b5a1e46-9282-4912-a314-98ef9c65edae" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-          <gml:pos>43.15 21.15</gml:pos>
-        </gml:Point>
-      </metce:position>
-    </metce:Volcano>
-  </iwxxm:eruptingVolcano>
+    </iwxxm:forecastPositionAnalysis>
+    <iwxxm:eruptingVolcano>
+        <metce:Volcano gml:id="uuid.8c2bf282-1268-4066-bfc9-a56f7ae999f5">
+            <metce:name>MT ASHVAL</metce:name>
+            <metce:position>
+                <gml:Point gml:id="uuid.2b5a1e46-9282-4912-a314-98ef9c65edae" uomLabels="deg deg" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>43.15 21.15</gml:pos>
+                </gml:Point>
+            </metce:position>
+        </metce:Volcano>
+    </iwxxm:eruptingVolcano>
 </iwxxm:VolcanicAshSIGMET>

--- a/3.0.0RC1/examples/sigmet-multi-location.xml
+++ b/3.0.0RC1/examples/sigmet-multi-location.xml
@@ -54,6 +54,7 @@
                     <aixm:type>OTHER:FIR_UIR</aixm:type>
                     <aixm:designator>YUDD</aixm:designator>
                     <aixm:name>SHANLON FIR/UIR</aixm:name>
+                    <!-- FIR boundary can be reported in an aixm:geometryComponent -->
                 </aixm:AirspaceTimeSlice>
             </aixm:timeSlice>
         </aixm:Airspace>

--- a/3.0.0RC1/examples/sigmet-multi-location.xml
+++ b/3.0.0RC1/examples/sigmet-multi-location.xml
@@ -9,13 +9,13 @@
       FCST 1800Z VA CLD APRX N4330 E02215 – N4315 E02345 – N4145 E02315 – N4230 E02200 - N4330 E02215
       FCST 1800Z VA CLD APRX N4200 E02145 – N4145 E02215 – N4100 E02215 - N4130 E02130 - N4200 E02145=
 -->
-<iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+<iwxxm:VolcanicAshSIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.b4d56d93-3866-4f75-b493-da9a4bb2404c"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">

--- a/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
+++ b/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
@@ -31,6 +31,12 @@
                                   YUDD SHANLON FIR INVALID TS"
             status="NORMAL">
         
+            <iwxxm:issueTime>
+                <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
+                    <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:issueTime>
+            
             <iwxxm:issuingAirTrafficServicesUnit>
               <aixm:Unit gml:id="uuid.8af40fb0-ea32-4192-81bf-f6f00b7d08b0">
                 <aixm:timeSlice>
@@ -58,7 +64,7 @@
               </aixm:Unit>
             </iwxxm:originatingMeteorologicalWatchOffice>
             
-            <iwxxm:flightInformationRegion>
+            <iwxxm:issuingAirTrafficServicesRegion>
                 <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
                     <aixm:timeSlice>
                         <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
@@ -70,16 +76,10 @@
                         </aixm:AirspaceTimeSlice>
                     </aixm:timeSlice>
                 </aixm:Airspace>
-            </iwxxm:flightInformationRegion>
+            </iwxxm:issuingAirTrafficServicesRegion>
             
             <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
             
-            <iwxxm:issueTime>
-                <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
-                    <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </iwxxm:issueTime>
-        
             <iwxxm:validPeriod>
                 <gml:TimePeriod gml:id="uuid.2635a879-81e5-4ac0-994f-b46050ba5e83">
                     <gml:beginPosition>2012-08-10T12:00:00Z</gml:beginPosition>

--- a/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
+++ b/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
@@ -8,24 +8,18 @@
 -->
 <collect:MeteorologicalBulletin
     xmlns:collect="http://def.wmo.int/collect/2014"
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
-    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:om="http://www.opengis.net/om/2.0"
-    xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-                        http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
-			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
+    xsi:schemaLocation="http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
     gml:id="uuid.fee171e9-1aec-4815-bcca-9e3c467388c6">
 
     <collect:meteorologicalInformation>
 	
-        <iwxxm:SIGMET 
+        <iwxxm:SIGMET
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.636569b5-6b9b-4ed7-aa60-ad373a9e372b"
             permissibleUsage="OPERATIONAL"
             translatedBulletinID="WSYU31 YUSO 101000"
@@ -64,7 +58,27 @@
               </aixm:Unit>
             </iwxxm:originatingMeteorologicalWatchOffice>
             
+            <iwxxm:flightInformationRegion>
+                <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
+                    <aixm:timeSlice>
+                        <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
+                            <gml:validTime/>
+                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                            <aixm:type>FIR</aixm:type>
+                            <aixm:designator>YUDD</aixm:designator>
+                            <aixm:name>SHANLON FIR</aixm:name>
+                        </aixm:AirspaceTimeSlice>
+                    </aixm:timeSlice>
+                </aixm:Airspace>
+            </iwxxm:flightInformationRegion>
+            
             <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
+            
+            <iwxxm:issueTime>
+                <gml:TimeInstant gml:id="uuid.5599e948-f719-4fc2-85fc-20ad96644250">
+                    <gml:timePosition>2012-08-10T12:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:issueTime>
         
             <iwxxm:validPeriod>
                 <gml:TimePeriod gml:id="uuid.2635a879-81e5-4ac0-994f-b46050ba5e83">

--- a/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
+++ b/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
@@ -18,8 +18,8 @@
         <iwxxm:SIGMET
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
-            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.636569b5-6b9b-4ed7-aa60-ad373a9e372b"
             permissibleUsage="OPERATIONAL"
             translatedBulletinID="WSYU31 YUSO 101000"

--- a/3.0.0RC1/examples/speci-A3-2.xml
+++ b/3.0.0RC1/examples/speci-A3-2.xml
@@ -6,147 +6,100 @@
         BECMG AT1200 8000 NSW NSC
 -->
 <iwxxm:SPECI xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:metce="http://def.wmo.int/metce/2013"
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:sf="http://www.opengis.net/sampling/2.0"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.8ca15300-d667-4364-86a1-ab8bec9ba833"
     status="NORMAL"
     permissibleUsage="OPERATIONAL"
     automatedStation="false">
+    
+    <iwxxm:aerodrome>
+        <!-- The aerodrome at which this observation took place -->
+        <aixm:AirportHeliport gml:id="uuid.84a7fdc6-ff14-470c-a4b4-587688f02049">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.fa9959d1-8c30-4b1e-b854-bc0fcaed64b9">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>YUDO</aixm:designator>
+                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
+    
+    <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="uuid.4929b573-d296-4261-bdf9-8d3e389ed72e">
+            <gml:timePosition>2012-08-15T11:15:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:observationTime>
+    
+    <iwxxm:observationLocation>
+        <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
+        <gml:Point gml:id="uuid.b5e759b2-a6e4-4d0d-80cd-718ef62932dd" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+            <gml:pos>12.34 -12.34</gml:pos>
+        </gml:Point>
+    </iwxxm:observationLocation>
 
     <iwxxm:observation>
-        <om:OM_Observation gml:id="uuid.b218a1a4-2aa4-4047-969a-dbc5403b5091">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeObservation"/>
-            <!-- time at which the observation actually occured -->
-            <om:phenomenonTime>
-                <gml:TimeInstant gml:id="uuid.4929b573-d296-4261-bdf9-8d3e389ed72e">
-                    <gml:timePosition>2012-08-15T11:15:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available (10-minutes later) -->
-            <om:resultTime>
-                <gml:TimeInstant gml:id="uuid.cb26ec9c-bf49-401a-8385-cafdb23b2d40">
-                    <gml:timePosition>2012-08-15T11:25:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </om:resultTime>
-            <om:procedure>
-                <metce:Process gml:id="uuid.53a0ae9b-d79d-4fb9-ad47-b320c0da2bf0">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 3 TECHNICAL SPECIFICATIONS RELATED TO METEOROLOGICAL OBSERVATIONS AND REPORTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeObservation"/>
-            <om:featureOfInterest>
-                <!-- featureOfInterest type and shape must refer to a point -->
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.9ec6d02d-9c90-4e8e-8844-91fb2c7eb2f6">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                    <sf:sampledFeature>
-                        <!-- The aerodrome at which this observation took place -->
-                        <aixm:AirportHeliport gml:id="uuid.84a7fdc6-ff14-470c-a4b4-587688f02049">
-                            <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="uuid.fa9959d1-8c30-4b1e-b854-bc0fcaed64b9">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:designator>YUDO</aixm:designator>
-                                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                                </aixm:AirportHeliportTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:AirportHeliport>
-                    </sf:sampledFeature>
-                    <sams:shape>
-                        <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                        <gml:Point gml:id="uuid.b5e759b2-a6e4-4d0d-80cd-718ef62932dd" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                            <gml:pos>12.34 -12.34</gml:pos>
-                        </gml:Point>
-                    </sams:shape>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <!-- The result of the observation -->
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeObservationRecord gml:id="uuid.1b08e09f-708f-496e-bea9-0c29378dca77" cloudAndVisibilityOK="false">
-                    <iwxxm:airTemperature uom="Cel">25.0</iwxxm:airTemperature>
-                    <iwxxm:dewpointTemperature uom="Cel">22.0</iwxxm:dewpointTemperature>
-                    <iwxxm:qnh uom="hPa">1008</iwxxm:qnh>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">50</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="[kn_i]">25.0</iwxxm:meanWindSpeed>
-                            <iwxxm:windGustSpeed uom="[kn_i]">37</iwxxm:windGustSpeed>
-                        </iwxxm:AerodromeSurfaceWind>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:visibility>
-                        <iwxxm:AerodromeHorizontalVisibility>
-                            <iwxxm:prevailingVisibility uom="m">3000</iwxxm:prevailingVisibility>
-                            <iwxxm:minimumVisibility uom="m">1200</iwxxm:minimumVisibility>
-                            <iwxxm:minimumVisibilityDirection uom="deg">45</iwxxm:minimumVisibilityDirection>
-                        </iwxxm:AerodromeHorizontalVisibility>
-                    </iwxxm:visibility>
-                    <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/+TSRA"/>
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeObservedClouds>
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
-                                    <iwxxm:base uom="[ft_i]">500</iwxxm:base>
-                                    <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeObservedClouds>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeObservationRecord>
-            </om:result>
-        </om:OM_Observation>
+        <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.1b08e09f-708f-496e-bea9-0c29378dca77" cloudAndVisibilityOK="false">
+            <iwxxm:airTemperature uom="Cel">25.0</iwxxm:airTemperature>
+            <iwxxm:dewpointTemperature uom="Cel">22.0</iwxxm:dewpointTemperature>
+            <iwxxm:qnh uom="hPa">1008</iwxxm:qnh>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">50</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="[kn_i]">25.0</iwxxm:meanWindSpeed>
+                    <iwxxm:windGustSpeed uom="[kn_i]">37</iwxxm:windGustSpeed>
+                </iwxxm:AerodromeSurfaceWind>
+            </iwxxm:surfaceWind>
+            <iwxxm:visibility>
+                <iwxxm:AerodromeHorizontalVisibility>
+                    <iwxxm:prevailingVisibility uom="m">3000</iwxxm:prevailingVisibility>
+                    <iwxxm:minimumVisibility uom="m">1200</iwxxm:minimumVisibility>
+                    <iwxxm:minimumVisibilityDirection uom="deg">45</iwxxm:minimumVisibilityDirection>
+                </iwxxm:AerodromeHorizontalVisibility>
+            </iwxxm:visibility>
+            <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/+TSRA"/>
+            <iwxxm:cloud>
+                <iwxxm:AerodromeObservedClouds>
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
+                            <iwxxm:base uom="[ft_i]">500</iwxxm:base>
+                            <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeObservedClouds>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeObservation>
     </iwxxm:observation>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="uuid.f159bbd9-bb16-4965-89c1-85719fe23587">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
-            <!-- time at which the forecast conditions actually occur -->
-            <om:phenomenonTime>
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.1fcd6178-2764-4b35-826a-4d167d37c558" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.ea6fb3d7-9a0f-4943-8b2c-ef0d3244edda">
                     <gml:beginPosition>2012-08-15T11:15:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-15T12:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime xlink:href="#ti-2012081511125"/>
-            <om:procedure xlink:href="#p-49-2-speci"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.1fcd6178-2764-4b35-826a-4d167d37c558" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
-                </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
+        </iwxxm:MeteorologicalAerodromeTrendForecast>
     </iwxxm:trendForecast>
     <iwxxm:trendForecast>
-        <om:OM_Observation gml:id="uuid.c5fae12c-6139-4da4-aa08-1674c11589fe">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeTrendForecast"/>
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.d3071042-2012-48c7-9e4e-df49ffc8a3b9" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
             <!-- time at which the forecast conditions actually occur -->
-            <om:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.9c559e62-d2f6-47df-b8cf-4b85b966d362">
                     <gml:timePosition>2012-08-15T12:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
-            </om:phenomenonTime>
-            <!-- time at which the results of the observation were made available -->
-            <om:resultTime xlink:href="#ti-2012081511125"/>
-            <om:procedure xlink:href="#p-49-2-speci"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeTrendForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeTrendForecastRecord gml:id="uuid.d3071042-2012-48c7-9e4e-df49ffc8a3b9" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">8000</iwxxm:prevailingVisibility>
-                    <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
-                    <iwxxm:cloud nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
-                </iwxxm:MeteorologicalAerodromeTrendForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">8000</iwxxm:prevailingVisibility>
+            <iwxxm:forecastWeather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+            <iwxxm:cloud nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+        </iwxxm:MeteorologicalAerodromeTrendForecast>
     </iwxxm:trendForecast>
 </iwxxm:SPECI>

--- a/3.0.0RC1/examples/speci-A3-2.xml
+++ b/3.0.0RC1/examples/speci-A3-2.xml
@@ -27,6 +27,11 @@
                     <aixm:designator>YUDO</aixm:designator>
                     <aixm:name>DONLON/INTERNATIONAL</aixm:name>
                     <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                    <aixm:ARP>
+                        <aixm:ElevatedPoint gml:id="uuid.b5e759b2-a6e4-4d0d-80cd-718ef62932dd" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                            <gml:pos>12.34 -12.34</gml:pos>
+                        </aixm:ElevatedPoint>
+                    </aixm:ARP>
                 </aixm:AirportHeliportTimeSlice>
             </aixm:timeSlice>
         </aixm:AirportHeliport>
@@ -45,13 +50,6 @@
         </gml:TimeInstant>
     </iwxxm:observationTime>
     
-    <iwxxm:observationLocation>
-        <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-        <gml:Point gml:id="uuid.b5e759b2-a6e4-4d0d-80cd-718ef62932dd" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-            <gml:pos>12.34 -12.34</gml:pos>
-        </gml:Point>
-    </iwxxm:observationLocation>
-
     <iwxxm:observation>
         <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.1b08e09f-708f-496e-bea9-0c29378dca77" cloudAndVisibilityOK="false">
             <iwxxm:airTemperature uom="Cel">25.0</iwxxm:airTemperature>

--- a/3.0.0RC1/examples/speci-A3-2.xml
+++ b/3.0.0RC1/examples/speci-A3-2.xml
@@ -5,12 +5,12 @@
       SPECI YUDO 151115Z 05025G37KT 3000 1200NE+TSRA BKN005CB 25/22 Q1008 TEMPO TL1200 0600
         BECMG AT1200 8000 NSW NSC
 -->
-<iwxxm:SPECI xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:xlink="http://www.w3.org/1999/xlink"
+<iwxxm:SPECI xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.8ca15300-d667-4364-86a1-ab8bec9ba833"
     status="NORMAL"

--- a/3.0.0RC1/examples/speci-A3-2.xml
+++ b/3.0.0RC1/examples/speci-A3-2.xml
@@ -32,6 +32,13 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
     
+    <!-- the same as observationTime except for corrections/re-issuances --> 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+            <gml:timePosition>2012-08-15T11:15:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:observationTime>
         <gml:TimeInstant gml:id="uuid.4929b573-d296-4261-bdf9-8d3e389ed72e">
             <gml:timePosition>2012-08-15T11:15:00Z</gml:timePosition>

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -4,10 +4,10 @@
     
       TAF YUDO 151800Z 1600/1618 13005MPS 9000 BKN020 BECMG 1606/1608 SCT015CB BKN020
       TEMPO 1608/1612 17006G12MPS 1000 TSRA SCT010CB BKN020 FM161230 15004MPS 9999 BKN020 -->
-<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
+<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.d6a85870-f32e-4ea8-8502-c7d9be7e0144"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -13,7 +13,7 @@
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
-    <!-- The aerodrome at which this observation took place -->
+    <!-- The aerodrome to which this TAF applies -->
     <iwxxm:aerodrome>
         <aixm:AirportHeliport gml:id="uuid.a5a157ad-5b93-443d-a8e6-8324816ccb7e">
             <aixm:timeSlice>
@@ -23,6 +23,11 @@
                     <aixm:designator>YUDO</aixm:designator>
                     <aixm:name>DONLON/INTERNATIONAL</aixm:name>
                     <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                    <aixm:ARP>
+                        <aixm:ElevatedPoint gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                            <gml:pos>12.34 -12.34</gml:pos>
+                        </aixm:ElevatedPoint>
+                    </aixm:ARP>
                 </aixm:AirportHeliportTimeSlice>
             </aixm:timeSlice>
         </aixm:AirportHeliport>
@@ -41,12 +46,6 @@
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validTime>
-    <!-- This is where the forecast took place, this is assumed to be representative of the sampledFeature -->
-    <iwxxm:forecastLocation>
-        <gml:Point gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-            <gml:pos>12.34 -12.34</gml:pos>
-        </gml:Point>
-    </iwxxm:forecastLocation>
     <iwxxm:baseForecast>
        <!-- Original TAF: 13005MPS 9000 BKN020 -->
         <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.13048235-8f8a-4587-a6be-e8ce99f4525c" cloudAndVisibilityOK="false">

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -5,18 +5,28 @@
       TAF YUDO 151800Z 1600/1618 13005MPS 9000 BKN020 BECMG 1606/1608 SCT015CB BKN020
       TEMPO 1608/1612 17006G12MPS 1000 TSRA SCT010CB BKN020 FM161230 15004MPS 9999 BKN020 -->
 <iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013" xmlns:sf="http://www.opengis.net/sampling/2.0"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.d6a85870-f32e-4ea8-8502-c7d9be7e0144"
     permissibleUsage="OPERATIONAL"
     status="NORMAL">
 
+    <!-- The aerodrome at which this observation took place -->
+    <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="uuid.a5a157ad-5b93-443d-a8e6-8324816ccb7e">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.9cf64bc2-0aca-452e-a330-9f6ce9f533e4">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>YUDO</aixm:designator>
+                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
     <iwxxm:issueTime>
         <!-- Original TAF: 151800Z -->
         <gml:TimeInstant gml:id="uuid.0c02ab83-22e8-4a66-b115-35544e7078f1">
@@ -31,203 +41,133 @@
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validTime>
+    <!-- This is where the forecast took place, this is assumed to be representative of the sampledFeature -->
+    <iwxxm:location>
+        <gml:Point gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+            <gml:pos>12.34 -12.34</gml:pos>
+        </gml:Point>
+    </iwxxm:location>
     <iwxxm:baseForecast>
-        <om:OM_Observation gml:id="uuid.8c744255-74a6-41f1-80d6-b7fbccd29f73">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
+       <!-- Original TAF: 13005MPS 9000 BKN020 -->
+        <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.13048235-8f8a-4587-a6be-e8ce99f4525c" cloudAndVisibilityOK="false">
             <!-- Base forecast phenomena occur throughout the valid period of the TAF -->
-            <om:phenomenonTime xlink:href="#tp-201208160000-201208161800"/>
-            <!-- resultTime is always the issueTime of the TAF -->
-            <om:resultTime xlink:href="#ti-201208151800Z"/>
+            <iwxxm:phenomenonTime xlink:href="#tp-201208160000-201208161800"/>
             <!-- base forecast conditions are valid throughout the TAF valid period -->
-            <om:validTime xlink:href="#tp-201208160000-201208161800"/>
-            <om:procedure>
-                <metce:Process gml:id="uuid.c785c5df-cf62-49d3-9a57-54e1203bf11d">
-                    <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 5 TECHNICAL SPECIFICATIONS RELATED TO FORECASTS</gml:description>
-                </metce:Process>
-            </om:procedure>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
-            <om:featureOfInterest>
-                <!-- featureOfInterest type and shape MUST refer to a sampling Point -->
-                <sams:SF_SpatialSamplingFeature gml:id="uuid.9072432c-6c36-4859-9e23-f7666e35b4bc">
-                    <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                    <sf:sampledFeature>
-                      <!-- The aerodrome at which this forecast takes place -->
-                        <aixm:AirportHeliport gml:id="uuid.a5a157ad-5b93-443d-a8e6-8324816ccb7e">
-                            <aixm:timeSlice>
-                                <aixm:AirportHeliportTimeSlice gml:id="uuid.9cf64bc2-0aca-452e-a330-9f6ce9f533e4">
-                                    <gml:validTime/>
-                                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                    <aixm:designator>YUDO</aixm:designator>
-                                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                                </aixm:AirportHeliportTimeSlice>
-                            </aixm:timeSlice>
-                        </aixm:AirportHeliport>
-                    </sf:sampledFeature>
-                    <sams:shape>
-                        <!-- This is where the forecast took place, this is assumed to be representative of the sampledFeature -->
-                        <gml:Point gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                            <gml:pos>12.34 -12.34</gml:pos>
-                        </gml:Point>
-                    </sams:shape>
-                </sams:SF_SpatialSamplingFeature>
-            </om:featureOfInterest>
-            <om:result>
-                <!-- Original TAF: 13005MPS 9000 BKN020 -->
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.13048235-8f8a-4587-a6be-e8ce99f4525c" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">9000</iwxxm:prevailingVisibility>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">130</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="m/s">5.0</iwxxm:meanWindSpeed>
-                        </iwxxm:AerodromeSurfaceWindForecast>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="uuid.cbd88f13-e806-4ab9-857f-b82a66cc2854">
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
-                                    <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeCloudForecast>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            <iwxxm:prevailingVisibility uom="m">9000</iwxxm:prevailingVisibility>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">130</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="m/s">5.0</iwxxm:meanWindSpeed>
+                </iwxxm:AerodromeSurfaceWindForecast>
+            </iwxxm:surfaceWind>
+            <iwxxm:cloud>
+                <iwxxm:AerodromeCloudForecast gml:id="uuid.cbd88f13-e806-4ab9-857f-b82a66cc2854">
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
+                            <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeCloudForecast>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeForecast>
     </iwxxm:baseForecast>
     <!-- Original TAF: BECMG 1606/1608 SCT015CB BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="uuid.bbda4671-37cd-4de0-8ab9-ff7845bcc853">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
-            <om:phenomenonTime>
+        <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.fe2635c8-3994-4423-b79f-123593fa2b55" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.921ff3f9-e89e-402e-acd1-82c8600f9929">
                     <gml:beginPosition>2012-08-16T06:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-16T08:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- resultTime is always the issueTime of the TAF -->
-            <om:resultTime xlink:href="#ti-201208151800Z"/>
-            <!-- This forecast phenomenon is not present outside of the phenomenonTime, but is still intended to be used during this period -->
-            <om:validTime xlink:href="#tp-201208160000-201208161800"/>
-            <om:procedure xlink:href="#p-49-2-taf"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.fe2635c8-3994-4423-b79f-123593fa2b55" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="uuid.235edc5d-213f-490b-8fdb-755032480849">
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
-                                    <iwxxm:base uom="[ft_i]">1500</iwxxm:base>
-                                    <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
-                                    <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeCloudForecast>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:cloud>
+                <iwxxm:AerodromeCloudForecast gml:id="uuid.235edc5d-213f-490b-8fdb-755032480849">
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
+                            <iwxxm:base uom="[ft_i]">1500</iwxxm:base>
+                            <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
+                            <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeCloudForecast>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeForecast>
     </iwxxm:changeForecast>
     <!-- Original TAF: TEMPO 1608/1612 17006G12MPS 1000 TSRA SCT010CB BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="uuid.c5cf385b-54f1-4b65-aee7-33714c40bbd0">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
-            <om:phenomenonTime>
+        <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.8985ba4e-f6f0-4dc2-8dd7-2cbf86a64056" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.5bdac885-79bf-4ebe-9693-cd0a4b2b91d0">
                     <gml:beginPosition>2012-08-16T08:00:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-16T12:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- resultTime is always the issueTime of the TAF -->
-            <om:resultTime xlink:href="#ti-201208151800Z"/>
-            <!-- This forecast phenomenon is not present outside of the phenomenonTime, but is still intended to be used during this period -->
-            <om:validTime xlink:href="#tp-201208160000-201208161800"/>
-            <om:procedure xlink:href="#p-49-2-taf"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.8985ba4e-f6f0-4dc2-8dd7-2cbf86a64056" changeIndicator="TEMPORARY_FLUCTUATIONS" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">1000</iwxxm:prevailingVisibility>
-                    <!-- Original TAF: 17006G12MPS -->
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">170</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="m/s">6</iwxxm:meanWindSpeed>
-                            <iwxxm:windGustSpeed uom="m/s">12</iwxxm:windGustSpeed>
-                        </iwxxm:AerodromeSurfaceWindForecast>
-                    </iwxxm:surfaceWind>
-                    <!-- Original TAF: TSRA -->
-                    <iwxxm:weather xlink:href="http://codes.wmo.int/306/4678/TSRA"/>
-                    <iwxxm:cloud>
-                        <!-- Original TAF: SCT010CB BKN020 -->
-                        <iwxxm:AerodromeCloudForecast gml:id="uuid.5d76e06c-220d-4491-83e8-439108891615">
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
-                                    <iwxxm:base uom="[ft_i]">1000</iwxxm:base>
-                                    <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
-                                    <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeCloudForecast>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">1000</iwxxm:prevailingVisibility>
+            <!-- Original TAF: 17006G12MPS -->
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">170</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="m/s">6</iwxxm:meanWindSpeed>
+                    <iwxxm:windGustSpeed uom="m/s">12</iwxxm:windGustSpeed>
+                </iwxxm:AerodromeSurfaceWindForecast>
+            </iwxxm:surfaceWind>
+            <!-- Original TAF: TSRA -->
+            <iwxxm:weather xlink:href="http://codes.wmo.int/306/4678/TSRA"/>
+            <iwxxm:cloud>
+                <!-- Original TAF: SCT010CB BKN020 -->
+                <iwxxm:AerodromeCloudForecast gml:id="uuid.5d76e06c-220d-4491-83e8-439108891615">
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/2"/>
+                            <iwxxm:base uom="[ft_i]">1000</iwxxm:base>
+                            <iwxxm:cloudType xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-012/9"/>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
+                            <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeCloudForecast>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeForecast>
     </iwxxm:changeForecast>
     <!-- Original TAF: FM161230 15004MPS 9999 BKN020 -->
     <iwxxm:changeForecast>
-        <om:OM_Observation gml:id="uuid.859f8b5b-ae0c-4167-9cd5-dc62d3df9913">
-            <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
-            <om:phenomenonTime>
+        <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.aeadfb00-4cfa-46b5-af21-1e79e4b6b1b5" changeIndicator="FROM" cloudAndVisibilityOK="false">
+            <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.06f40788-ea21-471e-8c17-c0ef5b581c98">
                     <gml:beginPosition>2012-08-16T12:30:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-17T00:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
-            </om:phenomenonTime>
-            <!-- resultTime is always the issueTime of the TAF -->
-            <om:resultTime xlink:href="#ti-201208151800Z"/>
-            <!-- This forecast phenomenon is not present outside of the phenomenonTime, but is still intended to be used during this period -->
-            <om:validTime xlink:href="#tp-201208160000-201208161800"/>
-            <om:procedure xlink:href="#p-49-2-taf"/>
-            <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
-            <om:featureOfInterest xlink:href="#sampling-point-03839"/>
-            <om:result>
-                <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="uuid.aeadfb00-4cfa-46b5-af21-1e79e4b6b1b5" changeIndicator="FROM" cloudAndVisibilityOK="false">
-                    <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
-                    <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
-                    <iwxxm:surfaceWind>
-                        <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
-                            <iwxxm:meanWindDirection uom="deg">150</iwxxm:meanWindDirection>
-                            <iwxxm:meanWindSpeed uom="m/s">4</iwxxm:meanWindSpeed>
-                        </iwxxm:AerodromeSurfaceWindForecast>
-                    </iwxxm:surfaceWind>
-                    <iwxxm:cloud>
-                        <iwxxm:AerodromeCloudForecast gml:id="uuid.ad9464f9-82de-49bd-8770-596b774591e5">
-                            <iwxxm:layer>
-                                <iwxxm:CloudLayer>
-                                    <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
-                                    <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
-                                </iwxxm:CloudLayer>
-                            </iwxxm:layer>
-                        </iwxxm:AerodromeCloudForecast>
-                    </iwxxm:cloud>
-                </iwxxm:MeteorologicalAerodromeForecastRecord>
-            </om:result>
-        </om:OM_Observation>
+            </iwxxm:phenomenonTime>
+            <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+            <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
+            <iwxxm:surfaceWind>
+                <iwxxm:AerodromeSurfaceWindForecast variableWindDirection="false">
+                    <iwxxm:meanWindDirection uom="deg">150</iwxxm:meanWindDirection>
+                    <iwxxm:meanWindSpeed uom="m/s">4</iwxxm:meanWindSpeed>
+                </iwxxm:AerodromeSurfaceWindForecast>
+            </iwxxm:surfaceWind>
+            <iwxxm:cloud>
+                <iwxxm:AerodromeCloudForecast gml:id="uuid.ad9464f9-82de-49bd-8770-596b774591e5">
+                    <iwxxm:layer>
+                        <iwxxm:CloudLayer>
+                            <iwxxm:amount xlink:href="http://codes.wmo.int/bufr4/codeflag/0-20-008/3"/>
+                            <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+                        </iwxxm:CloudLayer>
+                    </iwxxm:layer>
+                </iwxxm:AerodromeCloudForecast>
+            </iwxxm:cloud>
+        </iwxxm:MeteorologicalAerodromeForecast>
     </iwxxm:changeForecast>
 
 </iwxxm:TAF>

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -14,6 +14,12 @@
     status="NORMAL">
 
     <!-- The aerodrome to which this TAF applies -->
+    <iwxxm:issueTime>
+        <!-- Original TAF: 151800Z -->
+        <gml:TimeInstant gml:id="uuid.0c02ab83-22e8-4a66-b115-35544e7078f1">
+            <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
     <iwxxm:aerodrome>
         <aixm:AirportHeliport gml:id="uuid.a5a157ad-5b93-443d-a8e6-8324816ccb7e">
             <aixm:timeSlice>
@@ -32,12 +38,6 @@
             </aixm:timeSlice>
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
-    <iwxxm:issueTime>
-        <!-- Original TAF: 151800Z -->
-        <gml:TimeInstant gml:id="uuid.0c02ab83-22e8-4a66-b115-35544e7078f1">
-            <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>
         <!-- Original TAF: 1600/1618 -->

--- a/3.0.0RC1/examples/taf-A5-1.xml
+++ b/3.0.0RC1/examples/taf-A5-1.xml
@@ -42,11 +42,11 @@
         </gml:TimePeriod>
     </iwxxm:validTime>
     <!-- This is where the forecast took place, this is assumed to be representative of the sampledFeature -->
-    <iwxxm:location>
+    <iwxxm:forecastLocation>
         <gml:Point gml:id="uuid.4f5ce1f8-ae4c-4dea-99c7-6bc15ca6b004" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
             <gml:pos>12.34 -12.34</gml:pos>
         </gml:Point>
-    </iwxxm:location>
+    </iwxxm:forecastLocation>
     <iwxxm:baseForecast>
        <!-- Original TAF: 13005MPS 9000 BKN020 -->
         <iwxxm:MeteorologicalAerodromeForecast gml:id="uuid.13048235-8f8a-4587-a6be-e8ce99f4525c" cloudAndVisibilityOK="false">

--- a/3.0.0RC1/examples/taf-A5-2.xml
+++ b/3.0.0RC1/examples/taf-A5-2.xml
@@ -14,6 +14,12 @@
     permissibleUsage="OPERATIONAL"
     status="CANCELLATION">
 
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.2a142955-e0ef-4164-a550-ec80a3258150">
+            <gml:timePosition>2012-08-16T15:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:aerodrome>
         <aixm:AirportHeliport gml:id="uuid.65730df9-a2fd-4815-9d3f-d6f6770bc6cf">
             <aixm:timeSlice>
@@ -27,12 +33,6 @@
             </aixm:timeSlice>
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
-
-    <iwxxm:issueTime>
-        <gml:TimeInstant gml:id="uuid.2a142955-e0ef-4164-a550-ec80a3258150">
-            <gml:timePosition>2012-08-16T15:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
 
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>

--- a/3.0.0RC1/examples/taf-A5-2.xml
+++ b/3.0.0RC1/examples/taf-A5-2.xml
@@ -4,11 +4,11 @@
     
       TAF AMD YUDO 161500Z 1600/1618 CNL
 -->
-<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
+<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.dfbfe27c-3478-4efc-9800-124b90030e39"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/taf-A5-2.xml
+++ b/3.0.0RC1/examples/taf-A5-2.xml
@@ -14,6 +14,20 @@
     permissibleUsage="OPERATIONAL"
     status="CANCELLATION">
 
+    <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="uuid.65730df9-a2fd-4815-9d3f-d6f6770bc6cf">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.30a6076d-48ec-42df-bcd5-bf85220fe274">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>YUDO</aixm:designator>
+                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
+
     <iwxxm:issueTime>
         <gml:TimeInstant gml:id="uuid.2a142955-e0ef-4164-a550-ec80a3258150">
             <gml:timePosition>2012-08-16T15:00:00Z</gml:timePosition>
@@ -29,19 +43,7 @@
     </iwxxm:validTime>
 
     <!-- The Aerodrome of a previous report that is cancelled, amended or corrected -->
-    <iwxxm:previousReportAerodrome>
-        <aixm:AirportHeliport gml:id="uuid.65730df9-a2fd-4815-9d3f-d6f6770bc6cf">
-            <aixm:timeSlice>
-                <aixm:AirportHeliportTimeSlice gml:id="uuid.30a6076d-48ec-42df-bcd5-bf85220fe274">
-                    <gml:validTime/>
-                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                    <aixm:designator>YUDO</aixm:designator>
-                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                </aixm:AirportHeliportTimeSlice>
-            </aixm:timeSlice>
-        </aixm:AirportHeliport>
-    </iwxxm:previousReportAerodrome>
+    <iwxxm:previousReportAerodrome xlink:href="#uuid.65730df9-a2fd-4815-9d3f-d6f6770bc6cf"/>
 
     <!-- The valid time period of a previous report that is cancelled, amended or corrected by this report -->
     <iwxxm:previousReportValidPeriod>

--- a/3.0.0RC1/examples/taf-NIL-collect.xml
+++ b/3.0.0RC1/examples/taf-NIL-collect.xml
@@ -17,8 +17,8 @@
         <iwxxm:TAF
             xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
             xmlns:gml="http://www.opengis.net/gml/3.2"
-            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
-            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.ae3b123f-4fa1-447e-aa0e-5a950c8abff2"
             permissibleUsage="OPERATIONAL"
             status="MISSING">

--- a/3.0.0RC1/examples/taf-NIL-collect.xml
+++ b/3.0.0RC1/examples/taf-NIL-collect.xml
@@ -23,6 +23,12 @@
             permissibleUsage="OPERATIONAL"
             status="MISSING">
 
+            <iwxxm:issueTime>
+                <gml:TimeInstant gml:id="uuid.b28ba3dd-6544-4d7b-9a1f-342c63b458b5">
+                    <gml:timePosition>2012-08-16T00:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:issueTime>
+            
             <iwxxm:aerodrome>
                 <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
                     <aixm:timeSlice>
@@ -37,12 +43,6 @@
                 </aixm:AirportHeliport>
             </iwxxm:aerodrome>
         
-            <iwxxm:issueTime>
-                <gml:TimeInstant gml:id="uuid.b28ba3dd-6544-4d7b-9a1f-342c63b458b5">
-                    <gml:timePosition>2012-08-16T00:00:00Z</gml:timePosition>
-                </gml:TimeInstant>
-            </iwxxm:issueTime>
-
             <iwxxm:validTime nilReason="missing"/>
 
             <iwxxm:baseForecast nilReason="missing"/>

--- a/3.0.0RC1/examples/taf-NIL-collect.xml
+++ b/3.0.0RC1/examples/taf-NIL-collect.xml
@@ -7,77 +7,45 @@
 -->
 <collect:MeteorologicalBulletin
     xmlns:collect="http://def.wmo.int/collect/2014"	
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
     xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0" 
-    xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013" 
-    xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-                        http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-			http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
-			http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
+    xsi:schemaLocation="http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd"
     gml:id="uuid.507b41d4-2656-4f93-a1d7-2d01bd8e4c50">
 
    <collect:meteorologicalInformation>
 
-        <iwxxm:TAF 
+        <iwxxm:TAF
+            xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+            xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
             gml:id="uuid.ae3b123f-4fa1-447e-aa0e-5a950c8abff2"
             permissibleUsage="OPERATIONAL"
             status="MISSING">
+
+            <iwxxm:aerodrome>
+                <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
+                    <aixm:timeSlice>
+                        <aixm:AirportHeliportTimeSlice gml:id="uuid.64158cdb-c157-4df0-aba7-f2a385bb5935">
+                            <gml:validTime/>
+                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                            <aixm:designator>YUDO</aixm:designator>
+                            <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                            <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                        </aixm:AirportHeliportTimeSlice>
+                    </aixm:timeSlice>
+                </aixm:AirportHeliport>
+            </iwxxm:aerodrome>
         
             <iwxxm:issueTime>
                 <gml:TimeInstant gml:id="uuid.b28ba3dd-6544-4d7b-9a1f-342c63b458b5">
                     <gml:timePosition>2012-08-16T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </iwxxm:issueTime>
-        
-            <iwxxm:baseForecast>
-                <om:OM_Observation gml:id="uuid.314a496c-8cc4-419f-be94-f7ce233c3bfe">
-                    <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"/>
-                    <!-- time at which the missing report was found to be missing -->
-                    <om:phenomenonTime xlink:href="#ti-201208221600Z"/>
-                    <!-- time at which the results are made available -->
-                    <om:resultTime xlink:href="#ti-201208221600Z"/>
-                    <om:procedure>
-                        <metce:Process gml:id="uuid.057c06bd-c3ff-483d-a32d-9727fd2c6314">
-                            <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 5 TECHNICAL SPECIFICATIONS RELATED TO FORECASTS</gml:description>
-                        </metce:Process>
-                    </om:procedure>
-                    <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
-                    <om:featureOfInterest>
-                        <!-- featureOfInterest type and shape must refer to a point -->
-                        <sams:SF_SpatialSamplingFeature gml:id="uuid.f91de288-35ec-4386-89bc-41dd84a9df69">
-                            <sf:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                            <sf:sampledFeature>
-                                <!-- The aerodrome at which this observation took place -->
-                                <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
-                                    <aixm:timeSlice>
-                                        <aixm:AirportHeliportTimeSlice gml:id="uuid.64158cdb-c157-4df0-aba7-f2a385bb5935">
-                                            <gml:validTime/>
-                                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                                            <aixm:designator>YUDO</aixm:designator>
-                                            <aixm:name>DONLON/INTERNATIONAL</aixm:name>
-                                            <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
-                                        </aixm:AirportHeliportTimeSlice>
-                                    </aixm:timeSlice>
-                                </aixm:AirportHeliport>
-                            </sf:sampledFeature>
-                            <sams:shape>
-                                <!-- This is where the observation took place, assumed to be representative of the entire aerodrome -->
-                                <gml:Point gml:id="uuid.aedd0423-5540-49a0-954f-393b040450f4" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:pos>12.34 -12.34</gml:pos>
-                                </gml:Point>
-                            </sams:shape>
-                        </sams:SF_SpatialSamplingFeature>
-                    </om:featureOfInterest>
-                    <!-- The result of the observation -->
-                    <om:result nilReason="missing"/>
-                </om:OM_Observation>
-            </iwxxm:baseForecast>
+
+            <iwxxm:validTime nilReason="missing"/>
+
+            <iwxxm:baseForecast nilReason="missing"/>
         </iwxxm:TAF>
 
     </collect:meteorologicalInformation>

--- a/3.0.0RC1/examples/taf-translation-failed.xml
+++ b/3.0.0RC1/examples/taf-translation-failed.xml
@@ -4,10 +4,10 @@
     
       TAF YUDO 151800Z 1600/1618 INVALID
 -->
-<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
+<iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.fa3ce106-f401-4670-ae50-cdf76bf68912"
     permissibleUsage="OPERATIONAL"

--- a/3.0.0RC1/examples/taf-translation-failed.xml
+++ b/3.0.0RC1/examples/taf-translation-failed.xml
@@ -19,6 +19,13 @@
     translationFailedTAC="TAF YUDO 151800Z 1600/1618 INVALID"
     status="NORMAL">
 
+    <iwxxm:issueTime>
+        <!-- Original TAF: 151800Z -->
+        <gml:TimeInstant gml:id="uuid.1b9f7d3f-e09f-4d60-8fca-56b0de4dfebd">
+            <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
+    
     <iwxxm:aerodrome>
         <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
             <aixm:timeSlice>
@@ -33,12 +40,6 @@
         </aixm:AirportHeliport>
     </iwxxm:aerodrome>
 
-    <iwxxm:issueTime>
-        <!-- Original TAF: 151800Z -->
-        <gml:TimeInstant gml:id="uuid.1b9f7d3f-e09f-4d60-8fca-56b0de4dfebd">
-            <gml:timePosition>2012-08-15T18:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-    </iwxxm:issueTime>
     <!-- The time at which this TAF is intended to be used -->
     <iwxxm:validTime>
         <!-- Original TAF: 1600/1618 -->

--- a/3.0.0RC1/examples/taf-translation-failed.xml
+++ b/3.0.0RC1/examples/taf-translation-failed.xml
@@ -5,13 +5,9 @@
       TAF YUDO 151800Z 1600/1618 INVALID
 -->
 <iwxxm:TAF xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
-    xmlns:metce="http://def.wmo.int/metce/2013" xmlns:sf="http://www.opengis.net/sampling/2.0"
-    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd
-    http://def.wmo.int/metce/2013 http://schemas.wmo.int/metce/1.2/metce.xsd
-    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
 
     gml:id="uuid.fa3ce106-f401-4670-ae50-cdf76bf68912"
     permissibleUsage="OPERATIONAL"
@@ -22,6 +18,20 @@
     translationTime="2014-05-15T15:30:00Z"
     translationFailedTAC="TAF YUDO 151800Z 1600/1618 INVALID"
     status="NORMAL">
+
+    <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="uuid.b50f56f1-7291-40bb-90c1-5aad1e0ba833">
+            <aixm:timeSlice>
+                <aixm:AirportHeliportTimeSlice gml:id="uuid.64158cdb-c157-4df0-aba7-f2a385bb5935">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:designator>YUDO</aixm:designator>
+                    <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+                    <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+                </aixm:AirportHeliportTimeSlice>
+            </aixm:timeSlice>
+        </aixm:AirportHeliport>
+    </iwxxm:aerodrome>
 
     <iwxxm:issueTime>
         <!-- Original TAF: 151800Z -->

--- a/3.0.0RC1/examples/tc-advisory-A2-2.xml
+++ b/3.0.0RC1/examples/tc-advisory-A2-2.xml
@@ -24,10 +24,10 @@ NXT MSG:                    20040925/2000Z
 
 -->
 <iwxxm:TropicalCycloneAdvisory xmlns:gml="http://www.opengis.net/gml/3.2"
-   xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+   xmlns:iwxxm="http://icao.int/iwxxm/3.0"
    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+   xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
    gml:id="uuid.217b27d6-fbc0-499b-b58e-4ee062c86cd4" permissibleUsage="OPERATIONAL">
 
     <iwxxm:issueTime>

--- a/3.0.0RC1/examples/tc-advisory-A2-2.xml
+++ b/3.0.0RC1/examples/tc-advisory-A2-2.xml
@@ -126,11 +126,12 @@ NXT MSG:                    20040925/2000Z
     <!-- 24-hour forecast -->
     <iwxxm:forecast>
         <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.708829ef-4ca3-4229-b57c-5f1c937c3b2b">
-            <iwxxm:tropicalCyclonePosition>
-                <iwxxm:phenomenonTime>
+            <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.3d372d30-0a48-4d4b-9f9b-a27bbd764890">
                     <gml:timePosition>2004-09-26T16:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:tropicalCyclonePosition>
                 <gml:Point gml:id="uuid.d26643a3-1106-4003-9978-558cdbef0e78" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                     <gml:pos>29.2 -75.5</gml:pos>
                 </gml:Point>

--- a/3.0.0RC1/examples/tc-advisory-A2-2.xml
+++ b/3.0.0RC1/examples/tc-advisory-A2-2.xml
@@ -23,208 +23,126 @@ RMK:                        NIL
 NXT MSG:                    20040925/2000Z
 
 -->
-<iwxxm:TropicalCycloneAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-  xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
-  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-  xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
-  http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="uuid.217b27d6-fbc0-499b-b58e-4ee062c86cd4" permissibleUsage="OPERATIONAL">
+<iwxxm:TropicalCycloneAdvisory xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1"
+   xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+   gml:id="uuid.217b27d6-fbc0-499b-b58e-4ee062c86cd4" permissibleUsage="OPERATIONAL">
 
-  <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="uuid.d1858428-a96d-4825-aecd-07a929ab07d2">
-          <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
-      </gml:TimeInstant>
-  </iwxxm:issueTime>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.d1858428-a96d-4825-aecd-07a929ab07d2">
+            <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
-  <iwxxm:issuingTropicalCycloneAdvisoryCentre>
-    <aixm:Unit gml:id="uuid.f4fdc1cc-6bfa-4f4c-9ea9-df5e2c2bd762">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.42cdad72-4180-4cfe-afe9-f743f87088ef">
-          <gml:validTime/>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:type>OTHER:TCAC</aixm:type>
-          <aixm:designator>YUFO</aixm:designator>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:issuingTropicalCycloneAdvisoryCentre>
+    <iwxxm:issuingTropicalCycloneAdvisoryCentre>
+        <aixm:Unit gml:id="uuid.f4fdc1cc-6bfa-4f4c-9ea9-df5e2c2bd762">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.42cdad72-4180-4cfe-afe9-f743f87088ef">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:TCAC</aixm:type>
+                    <aixm:designator>YUFO</aixm:designator>
+                </aixm:UnitTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Unit>
+    </iwxxm:issuingTropicalCycloneAdvisoryCentre>
 
-  <iwxxm:tropicalCycloneName>GLORIA</iwxxm:tropicalCycloneName>
-  <iwxxm:advisoryNumber>01</iwxxm:advisoryNumber>
+    <iwxxm:tropicalCycloneName>GLORIA</iwxxm:tropicalCycloneName>
+    <iwxxm:advisoryNumber>01</iwxxm:advisoryNumber>
 
-  <iwxxm:observation>
-    <om:OM_Observation gml:id="uuid.720fbd91-a522-4872-a1d7-a512075dc1a6">
-      <om:phenomenonTime>
-       <gml:TimeInstant gml:id="uuid.023a036d-6945-492b-b9e5-30bf5df83179">
-         <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
-       </gml:TimeInstant>
-      </om:phenomenonTime>
-      <!-- time at which the results of the observation were made available -->
-      <om:resultTime xlink:href="#ti-200409251600"/>
-      <om:procedure>
-        <metce:Process gml:id="uuid.c09f7e9e-0ec6-4091-b0d8-3e500ed711af">
-          <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 2 Tropical cyclone advisory information</gml:description>
-        </metce:Process>
-      </om:procedure>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneObservedConditions"/>
-      <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="uuid.d0e29da6-c205-4421-beb7-a35440a2e088">
-              <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-              <sam:sampledFeature xlink:href="#tcac-YUFO"/>
-              <!-- TC centre -->
-              <sams:shape>
-                  <gml:Point gml:id="uuid.8b4b12ed-461a-4716-8191-6cf41ad77471" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:pos>27.1 -73.1</gml:pos>
-                  </gml:Point>
-              </sams:shape>
-          </sams:SF_SpatialSamplingFeature>
-      </om:featureOfInterest>
-      <om:result>
+    <iwxxm:observation>
         <iwxxm:TropicalCycloneObservedConditions gml:id="uuid.78eddcd7-acfe-4649-b633-36189eaffc5d">
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.023a036d-6945-492b-b9e5-30bf5df83179">
+                    <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:tropicalCyclonePosition>
+                <gml:Point gml:id="uuid.8b4b12ed-461a-4716-8191-6cf41ad77471" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>27.1 -73.1</gml:pos>
+                </gml:Point>
+            </iwxxm:tropicalCyclonePosition>
             <iwxxm:movement>MOVING</iwxxm:movement>
             <iwxxm:movementDirection uom="deg">315</iwxxm:movementDirection>
             <iwxxm:movementSpeed uom="km/h">20</iwxxm:movementSpeed>
             <iwxxm:centralPressure uom="hPa">965</iwxxm:centralPressure>
             <iwxxm:meanMaxSurfaceWind uom="m/s">22</iwxxm:meanMaxSurfaceWind>
         </iwxxm:TropicalCycloneObservedConditions>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:observation>
+    </iwxxm:observation>
 
-  <!-- 6-hour forecast at 25/2200Z -->
-  <iwxxm:forecast>
-    <om:OM_Observation gml:id="uuid.1d8eae14-fca6-4247-9e13-dda703a2ee91">
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.6b115305-4200-4053-8ddb-0d036f907b69">
-          <gml:timePosition>2004-09-25T22:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:phenomenonTime>
-      <!-- time at which the results of the observation were made available -->
-      <om:resultTime xlink:href="#ti-200409251600"/>
-      <om:procedure xlink:href="#p-49-2"/>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
-      <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="uuid.6b369dd3-1c28-422a-bd49-56378b138e5e">
-              <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-              <sam:sampledFeature xlink:href="#tcac-YUFO"/>
-              <!-- TC centre -->
-              <sams:shape>
-                  <gml:Point gml:id="uuid.e91ca02c-3625-4cdb-928c-d7979d45f2bc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                      <gml:pos>27.8 -73.83333</gml:pos>
-                  </gml:Point>
-              </sams:shape>
-          </sams:SF_SpatialSamplingFeature>
-      </om:featureOfInterest>
-      <om:result>
+    <!-- 6-hour forecast at 25/2200Z -->
+    <iwxxm:forecast>
         <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.75adc697-201c-485d-8356-1845ad46ae77">
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.6b115305-4200-4053-8ddb-0d036f907b69">
+                    <gml:timePosition>2004-09-25T22:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:tropicalCyclonePosition>
+                <gml:Point gml:id="uuid.e91ca02c-3625-4cdb-928c-d7979d45f2bc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>27.8 -73.83333</gml:pos>
+                </gml:Point>
+            </iwxxm:tropicalCyclonePosition>
             <iwxxm:maximumSurfaceWindSpeed uom="m/s">22</iwxxm:maximumSurfaceWindSpeed>
         </iwxxm:TropicalCycloneForecastConditions>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:forecast>
+    </iwxxm:forecast>
 
-  <!-- 12 hour forecast at 26/0400Z -->
-  <iwxxm:forecast>
-      <om:OM_Observation gml:id="uuid.598b9b20-c9d4-40ef-8a35-04fe4df8db5e">
-          <om:phenomenonTime>
-              <gml:TimeInstant gml:id="uuid.b7991033-e147-4b77-8589-226c8eea39d4">
-                  <gml:timePosition>2004-09-26T04:00:00Z</gml:timePosition>
-              </gml:TimeInstant>
-          </om:phenomenonTime>
-          <!-- time at which the results of the observation were made available -->
-          <om:resultTime xlink:href="#ti-200409251600"/>
-          <om:procedure xlink:href="#p-49-2"/>
-          <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
-          <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="uuid.7f43de4b-5679-4355-a93f-d1931841f698">
-                  <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                  <sam:sampledFeature xlink:href="#tcac-YUFO"/>
-                  <!-- TC centre -->
-                  <sams:shape>
-                      <gml:Point gml:id="uuid.2e386620-5d45-4b7d-b171-4013f10f5ddc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                          <gml:pos>28.5 -74.5</gml:pos>
-                      </gml:Point>
-                  </sams:shape>
-              </sams:SF_SpatialSamplingFeature>
-          </om:featureOfInterest>
-          <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.13515111-4e81-4b60-85a7-eedc2b5f874f">
-                  <iwxxm:maximumSurfaceWindSpeed uom="m/s">22</iwxxm:maximumSurfaceWindSpeed>
-              </iwxxm:TropicalCycloneForecastConditions>
-          </om:result>
-      </om:OM_Observation>
-  </iwxxm:forecast>
+    <!-- 12 hour forecast at 26/0400Z -->
+    <iwxxm:forecast>
+        <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.13515111-4e81-4b60-85a7-eedc2b5f874f">
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.b7991033-e147-4b77-8589-226c8eea39d4">
+                    <gml:timePosition>2004-09-26T04:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:tropicalCyclonePosition>
+                <gml:Point gml:id="uuid.2e386620-5d45-4b7d-b171-4013f10f5ddc" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>28.5 -74.5</gml:pos>
+                </gml:Point>
+            </iwxxm:tropicalCyclonePosition>
+            <iwxxm:maximumSurfaceWindSpeed uom="m/s">22</iwxxm:maximumSurfaceWindSpeed>
+        </iwxxm:TropicalCycloneForecastConditions>
+    </iwxxm:forecast>
 
-  <!-- 18-hour forecast -->
-  <iwxxm:forecast>
-      <om:OM_Observation gml:id="uuid.50a39248-b6eb-4e9c-99d3-19e8d58b4d4e">
-          <om:phenomenonTime>
-              <gml:TimeInstant gml:id="uuid.a747f059-2d07-4ba7-9317-c7e7eddc5adf">
-                  <gml:timePosition>2004-09-26T10:00:00Z</gml:timePosition>
-              </gml:TimeInstant>
-          </om:phenomenonTime>
-          <!-- time at which the results of the observation were made available -->
-          <om:resultTime xlink:href="#ti-200409251600"/>
-          <om:procedure xlink:href="#p-49-2"/>
-          <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
-          <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="uuid.e10eddd3-3157-44d7-a8a1-94d50342d31e">
-                  <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                  <sam:sampledFeature xlink:href="#tcac-YUFO"/>
-                  <!-- TC centre -->
-                  <sams:shape>
-                      <gml:Point gml:id="uuid.6dc4b702-ea53-4dc0-a261-ff8931bc84db" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                          <gml:pos>28.86667 -75.00</gml:pos>
-                      </gml:Point>
-                  </sams:shape>
-              </sams:SF_SpatialSamplingFeature>
-          </om:featureOfInterest>
-          <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.6c9b5a04-8be5-4a3e-8cb8-590e6a67d159">
-                  <iwxxm:maximumSurfaceWindSpeed uom="m/s">21</iwxxm:maximumSurfaceWindSpeed>
-              </iwxxm:TropicalCycloneForecastConditions>
-          </om:result>
-      </om:OM_Observation>
-  </iwxxm:forecast>
+    <!-- 18-hour forecast -->
+    <iwxxm:forecast>
+        <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.6c9b5a04-8be5-4a3e-8cb8-590e6a67d159">
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.a747f059-2d07-4ba7-9317-c7e7eddc5adf">
+                    <gml:timePosition>2004-09-26T10:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:tropicalCyclonePosition>
+                <gml:Point gml:id="uuid.6dc4b702-ea53-4dc0-a261-ff8931bc84db" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>28.86667 -75.00</gml:pos>
+                </gml:Point>
+            </iwxxm:tropicalCyclonePosition>
+            <iwxxm:maximumSurfaceWindSpeed uom="m/s">21</iwxxm:maximumSurfaceWindSpeed>
+        </iwxxm:TropicalCycloneForecastConditions>
+    </iwxxm:forecast>
 
-  <!-- 24-hour forecast -->
-  <iwxxm:forecast>
-      <om:OM_Observation gml:id="uuid.10953e18-32c7-4cee-837b-b26d0f19d97e">
-          <om:phenomenonTime>
-              <gml:TimeInstant gml:id="uuid.3d372d30-0a48-4d4b-9f9b-a27bbd764890">
-                  <gml:timePosition>2004-09-26T16:00:00Z</gml:timePosition>
-              </gml:TimeInstant>
-          </om:phenomenonTime>
-          <!-- time at which the results of the observation were made available -->
-          <om:resultTime xlink:href="#ti-200409251600"/>
-          <om:procedure xlink:href="#p-49-2"/>
-          <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/TropicalCycloneForecastConditions"/>
-          <om:featureOfInterest>
-              <sams:SF_SpatialSamplingFeature gml:id="uuid.f06fae34-714f-48d2-8e5d-ec5b0ee3684e">
-                  <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
-                  <sam:sampledFeature xlink:href="#tcac-YUFO"/>
-                  <!-- TC centre -->
-                  <sams:shape>
-                      <gml:Point gml:id="uuid.d26643a3-1106-4003-9978-558cdbef0e78" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                          <gml:pos>29.2 -75.5</gml:pos>
-                      </gml:Point>
-                  </sams:shape>
-              </sams:SF_SpatialSamplingFeature>
-          </om:featureOfInterest>
-          <om:result>
-              <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.708829ef-4ca3-4229-b57c-5f1c937c3b2b">
-                  <iwxxm:maximumSurfaceWindSpeed uom="m/s">20</iwxxm:maximumSurfaceWindSpeed>
-              </iwxxm:TropicalCycloneForecastConditions>
-          </om:result>
-      </om:OM_Observation>
-  </iwxxm:forecast>
+    <!-- 24-hour forecast -->
+    <iwxxm:forecast>
+        <iwxxm:TropicalCycloneForecastConditions gml:id="uuid.708829ef-4ca3-4229-b57c-5f1c937c3b2b">
+            <iwxxm:tropicalCyclonePosition>
+                <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.3d372d30-0a48-4d4b-9f9b-a27bbd764890">
+                    <gml:timePosition>2004-09-26T16:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+                <gml:Point gml:id="uuid.d26643a3-1106-4003-9978-558cdbef0e78" axisLabels="Lat Lon" srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:pos>29.2 -75.5</gml:pos>
+                </gml:Point>
+            </iwxxm:tropicalCyclonePosition>
+            <iwxxm:maximumSurfaceWindSpeed uom="m/s">20</iwxxm:maximumSurfaceWindSpeed>
+        </iwxxm:TropicalCycloneForecastConditions>
+    </iwxxm:forecast>
 
-  <iwxxm:expectedNextAdvisoryTime>
-    <gml:TimeInstant gml:id="uuid.002b0056-d267-47b7-a9ef-4c7ca70aacd9">
-      <gml:timePosition>2004-09-25T20:00:00Z</gml:timePosition>
-    </gml:TimeInstant>
-  </iwxxm:expectedNextAdvisoryTime>
+    <iwxxm:expectedNextAdvisoryTime>
+        <gml:TimeInstant gml:id="uuid.002b0056-d267-47b7-a9ef-4c7ca70aacd9">
+            <gml:timePosition>2004-09-25T20:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:expectedNextAdvisoryTime>
 
 </iwxxm:TropicalCycloneAdvisory>

--- a/3.0.0RC1/examples/tc-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/tc-advisory-translation-failed.xml
@@ -9,63 +9,50 @@ TC:                         GLORIA
 INVALID INVALID INVALID
 -->
 <iwxxm:TropicalCycloneAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-  xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
-  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-  xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
-  http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="uuid.4a954e38-b132-4d3c-aaba-90dbd056d497" permissibleUsage="OPERATIONAL"
-  translatedBulletinID="TTAAiiCCCYYGGgg"
-  translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
-  translationCentreDesignator="YUZZ"
-  translationCentreName="Fictional translation centre"
-  translationTime="2014-05-15T15:30:00Z"
-  translationFailedTAC="TC ADVISORY
-  
-  DTG:                        20040925/1600Z
-  TCAC:                       YUFO
-  TC:                         GLORIA
-  INVALID INVALID INVALID">
+    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+    xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    gml:id="uuid.4a954e38-b132-4d3c-aaba-90dbd056d497" permissibleUsage="OPERATIONAL"
+    translatedBulletinID="TTAAiiCCCYYGGgg"
+    translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
+    translationCentreDesignator="YUZZ"
+    translationCentreName="Fictional translation centre"
+    translationTime="2014-05-15T15:30:00Z"
+    translationFailedTAC="TC ADVISORY
+    
+    DTG:                        20040925/1600Z
+    TCAC:                       YUFO
+    TC:                         GLORIA
+    INVALID INVALID INVALID">
 
-  <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="uuid.3ea6b416-595b-4eb0-ad4c-3879fa5726d2">
-          <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
-      </gml:TimeInstant>
-  </iwxxm:issueTime>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.3ea6b416-595b-4eb0-ad4c-3879fa5726d2">
+            <gml:timePosition>2004-09-25T16:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
-  <iwxxm:issuingTropicalCycloneAdvisoryCentre>
-    <aixm:Unit gml:id="uuid.cf31d51c-7cac-4541-9183-5b295f56ae99">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.11e05972-5994-43f9-ab66-307b6d22fe89">
-          <gml:validTime>
-            <gml:TimePeriod gml:id="uuid.612e584d-774c-4408-a6a7-762180f240c6">
-              <gml:beginPosition>2004-01-01T00:00:00Z</gml:beginPosition>
-              <gml:endPosition indeterminatePosition="unknown"/>
-            </gml:TimePeriod>
-          </gml:validTime>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:featureLifetime>
-            <gml:TimePeriod gml:id="uuid.7da41706-7660-4e0d-a26d-a00cc8b2ea87">
-              <gml:beginPosition>2004-01-01T00:00:00Z</gml:beginPosition>
-              <gml:endPosition indeterminatePosition="unknown"/>
-            </gml:TimePeriod>
-          </aixm:featureLifetime>
-          <aixm:type>OTHER:TCAC</aixm:type>
-          <aixm:designator>YUFO</aixm:designator>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:issuingTropicalCycloneAdvisoryCentre>
+    <iwxxm:issuingTropicalCycloneAdvisoryCentre>
+        <aixm:Unit gml:id="uuid.cf31d51c-7cac-4541-9183-5b295f56ae99">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.11e05972-5994-43f9-ab66-307b6d22fe89">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:type>OTHER:TCAC</aixm:type>
+                    <aixm:designator>YUFO</aixm:designator>
+                </aixm:UnitTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Unit>
+    </iwxxm:issuingTropicalCycloneAdvisoryCentre>
 
-  <iwxxm:tropicalCycloneName>GLORIA</iwxxm:tropicalCycloneName>
-  <iwxxm:advisoryNumber>0</iwxxm:advisoryNumber>
+    <iwxxm:tropicalCycloneName>GLORIA</iwxxm:tropicalCycloneName>
+    <iwxxm:advisoryNumber>0</iwxxm:advisoryNumber>
 
-  <iwxxm:observation nilReason="missing"/>
-  <iwxxm:forecast nilReason="missing"/>
-  <iwxxm:forecast nilReason="missing"/>
-  <iwxxm:forecast nilReason="missing"/>
-  <iwxxm:forecast nilReason="missing"/>
-  <iwxxm:expectedNextAdvisoryTime></iwxxm:expectedNextAdvisoryTime>
+    <iwxxm:observation nilReason="missing"/>
+    <iwxxm:forecast nilReason="missing"/>
+    <iwxxm:forecast nilReason="missing"/>
+    <iwxxm:forecast nilReason="missing"/>
+    <iwxxm:forecast nilReason="missing"/>
+    <iwxxm:expectedNextAdvisoryTime/>
 
 </iwxxm:TropicalCycloneAdvisory>

--- a/3.0.0RC1/examples/tc-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/tc-advisory-translation-failed.xml
@@ -9,10 +9,10 @@ TC:                         GLORIA
 INVALID INVALID INVALID
 -->
 <iwxxm:TropicalCycloneAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+    xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:metce="http://def.wmo.int/metce/2013"
     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
     gml:id="uuid.4a954e38-b132-4d3c-aaba-90dbd056d497" permissibleUsage="OPERATIONAL"
     translatedBulletinID="TTAAiiCCCYYGGgg"
     translatedBulletinReceptionTime="2014-05-15T15:29:00Z"

--- a/3.0.0RC1/examples/va-advisory-A2-1.xml
+++ b/3.0.0RC1/examples/va-advisory-A2-1.xml
@@ -30,282 +30,234 @@ NXT ADVISORY:               20080923/0730Z
 
 -->
 <iwxxm:VolcanicAshAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-  xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
-  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-  xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
-  http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="uuid.fb4861a8-0438-4f17-b8a7-efc13de58dec" permissibleUsage="OPERATIONAL">
+   xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+   xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+   gml:id="uuid.fb4861a8-0438-4f17-b8a7-efc13de58dec" permissibleUsage="OPERATIONAL">
 
-  <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="uuid.efc2bc1b-fb52-4d66-ad22-73fcb857e8a3">
-          <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
-      </gml:TimeInstant>
-  </iwxxm:issueTime>
-
-  <iwxxm:issuingVolcanicAshAdvisoryCentre>
-    <aixm:Unit gml:id="uuid.456ad302-8380-45c9-b090-143bad6d4a0b">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.9df94924-690e-4d9c-8025-8883c619b747">
-          <gml:validTime/>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>TOKYO</aixm:name>
-          <aixm:type>OTHER:VACC</aixm:type>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:issuingVolcanicAshAdvisoryCentre>
-
-  <iwxxm:volcano>
-    <metce:EruptingVolcano gml:id="uuid.1b9ee023-c87d-4fa0-bf9b-bb1c7215286c">
-      <gml:description>FL300 REPORTED</gml:description>
-      <metce:name>KARYMSKY 1000-13</metce:name>
-      <metce:position>
-        <gml:Point gml:id="uuid.687c6e95-460a-4397-a602-ea8483acc3fc" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-            <gml:pos>54.03 159.27 1536</gml:pos>
-        </gml:Point>
-      </metce:position>
-      <metce:eruptionDate>2008-09-23T01:30:00Z</metce:eruptionDate>
-    </metce:EruptingVolcano>
-  </iwxxm:volcano>
-
-  <iwxxm:advisoryNumber>2008/4</iwxxm:advisoryNumber>
-  <iwxxm:informationSource>MTSAT-1R KVERT KEMSD</iwxxm:informationSource>
-  <iwxxm:colourCode xlink:href="http://codes.wmo.int/49-2/AviationColourCode/RED"/>
-
-  <iwxxm:analysis>
-    <om:OM_Observation gml:id="uuid.f87d3aac-607c-4f10-8133-561d0fd7de8f">
-      <om:phenomenonTime>
-       <gml:TimeInstant gml:id="uuid.d894fd2c-890f-4c36-81b2-ae8576765929">
-         <gml:timePosition>2008-09-23T01:00:00Z</gml:timePosition>
-       </gml:TimeInstant>
-      </om:phenomenonTime>
-      <!-- time at which the results of the observation were made available -->
-      <om:resultTime>
-        <gml:TimeInstant gml:id="uuid.e7b1f336-e00f-4b06-b41a-76bf4c645bc1">
-          <gml:timePosition>2008-09-23T00:00:00Z</gml:timePosition>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.efc2bc1b-fb52-4d66-ad22-73fcb857e8a3">
+            <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
         </gml:TimeInstant>
-      </om:resultTime>
-      <om:procedure>
-        <metce:Process gml:id="uuid.9c55c6d7-9dac-47e4-8c91-5547714a8568">
-          <gml:description>WMO No. 49 Volume 2 Meteorological Service for International Air Navigation APPENDIX 2 Volcanic ash advisory information</gml:description>
-        </metce:Process>
-      </om:procedure>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
-      <om:featureOfInterest>
-          <sams:SF_SpatialSamplingFeature gml:id="uuid.29743bd4-f637-41d3-81ce-30eae66d2931">
-              <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingSurface"/>
-              <sam:sampledFeature xlink:href="#vaac-TOKYO"/>
-              <!-- VAAC boundary - not typically reported -->
-              <sams:shape nilReason="withheld"/>
-          </sams:SF_SpatialSamplingFeature>
-      </om:featureOfInterest>
-      <om:result>
+    </iwxxm:issueTime>
+
+    <iwxxm:issuingVolcanicAshAdvisoryCentre>
+        <aixm:Unit gml:id="uuid.456ad302-8380-45c9-b090-143bad6d4a0b">
+            <aixm:timeSlice>
+                <aixm:UnitTimeSlice gml:id="uuid.9df94924-690e-4d9c-8025-8883c619b747">
+                    <gml:validTime/>
+                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                    <aixm:name>TOKYO</aixm:name>
+                    <aixm:type>OTHER:VACC</aixm:type>
+                </aixm:UnitTimeSlice>
+            </aixm:timeSlice>
+        </aixm:Unit>
+    </iwxxm:issuingVolcanicAshAdvisoryCentre>
+
+    <iwxxm:volcano>
+        <metce:EruptingVolcano gml:id="uuid.1b9ee023-c87d-4fa0-bf9b-bb1c7215286c">
+            <gml:description>FL300 REPORTED</gml:description>
+            <metce:name>KARYMSKY 1000-13</metce:name>
+            <metce:position>
+                <gml:Point gml:id="uuid.687c6e95-460a-4397-a602-ea8483acc3fc" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+                    <gml:pos>54.03 159.27 1536</gml:pos>
+                </gml:Point>
+            </metce:position>
+            <metce:eruptionDate>2008-09-23T01:30:00Z</metce:eruptionDate>
+        </metce:EruptingVolcano>
+    </iwxxm:volcano>
+
+    <iwxxm:advisoryNumber>2008/4</iwxxm:advisoryNumber>
+    <iwxxm:informationSource>MTSAT-1R KVERT KEMSD</iwxxm:informationSource>
+    <iwxxm:colourCode xlink:href="http://codes.wmo.int/49-2/AviationColourCode/RED"/>
+
+    <iwxxm:analysis>
         <iwxxm:VolcanicAshConditions gml:id="uuid.3182220e-b8ab-40f6-9be9-190b32b3d40e">
-          <!-- FL250/300 N5400 E15930 N5400 E16100 N5300 E15945 MOV SE 20KT -->
-          <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="uuid.4dd54d1a-9a18-4065-b9e9-a0f25ced8f17">
-                <iwxxm:ashCloudExtent nilReason="unknown">
-                    <aixm:AirspaceVolume gml:id="uuid.ca49fe24-81a5-4591-9d59-df21ea49d252">
-                        <aixm:upperLimit uom="FL">300</aixm:upperLimit>
-                        <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                        <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
-                        <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
-                        <aixm:horizontalProjection>
-                            <aixm:Surface gml:id="uuid.c81a85cc-61d9-4250-b9bb-fe4e9dcd3f29">
-                                <gml:patches>
-                                    <gml:PolygonPatch>
-                                        <gml:exterior>
-                                            <gml:LinearRing>
-                                                <gml:posList>54.00 159.50 54.00 161.00 53.00 159.75 54.00 159.50</gml:posList>
-                                            </gml:LinearRing>
-                                        </gml:exterior>
-                                    </gml:PolygonPatch>
-                                </gml:patches>
-                            </aixm:Surface>
-                        </aixm:horizontalProjection>
-                    </aixm:AirspaceVolume>
-                </iwxxm:ashCloudExtent>
-                <iwxxm:directionOfMotion uom="deg">135</iwxxm:directionOfMotion>
-                <iwxxm:speedOfMotion uom="[kn_i]">20</iwxxm:speedOfMotion>
-            </iwxxm:VolcanicAshCloud>
-          </iwxxm:ashCloud>
-          <!-- SFC/FL200 N5130 E16130 N5130 E16230 N5230 E16230 N5230 E16130 MOV SE 15KT -->
-          <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="uuid.1f272bcf-ff35-45fe-9206-7963d574c752">
-              <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="uuid.d8a40c1f-5026-47bc-b121-ba2cddbdae94">
-                  <aixm:upperLimit uom="FL">200</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit>GND</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.5d5747e4-da0c-4b2e-8a18-7c2d6c72d76c">
-                      <gml:patches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>51.50 161.50 51.50 162.50 52.50 162.50 52.50 161.50 51.50 161.50</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:patches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:ashCloudExtent>
-              <iwxxm:directionOfMotion uom="deg">135</iwxxm:directionOfMotion>
-              <iwxxm:speedOfMotion uom="[kn_i]">15</iwxxm:speedOfMotion>
-            </iwxxm:VolcanicAshCloud>
-          </iwxxm:ashCloud>
-        </iwxxm:VolcanicAshConditions>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:analysis>
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.d894fd2c-890f-4c36-81b2-ae8576765929">
+                    <gml:timePosition>2008-09-23T01:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
 
-  <!-- 23/0700Z -->
-  <iwxxm:analysis>
-    <om:OM_Observation gml:id="uuid.9584191b-5246-40e1-b747-bfd136ffd578">
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.7d89ec7f-6266-47d0-8f97-af0cd0905e9a">
-          <gml:timePosition>2008-09-23T07:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:phenomenonTime>
-      <!-- time at which the results of the observation were made available -->
-      <om:resultTime xlink:href="#ti-2"/>
-      <om:procedure xlink:href="#p-49-2"/>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
-      <om:featureOfInterest xlink:href="#ssf1"/>
-      <om:result>
+            <!-- FL250/300 N5400 E15930 N5400 E16100 N5300 E15945 MOV SE 20KT -->
+            <iwxxm:ashCloud>
+                <iwxxm:VolcanicAshCloud gml:id="uuid.4dd54d1a-9a18-4065-b9e9-a0f25ced8f17">
+                    <iwxxm:ashCloudExtent nilReason="unknown">
+                        <aixm:AirspaceVolume gml:id="uuid.ca49fe24-81a5-4591-9d59-df21ea49d252">
+                            <aixm:upperLimit uom="FL">300</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.c81a85cc-61d9-4250-b9bb-fe4e9dcd3f29">
+                                    <gml:patches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>54.00 159.50 54.00 161.00 53.00 159.75 54.00 159.50</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:patches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:ashCloudExtent>
+                    <iwxxm:directionOfMotion uom="deg">135</iwxxm:directionOfMotion>
+                    <iwxxm:speedOfMotion uom="[kn_i]">20</iwxxm:speedOfMotion>
+                </iwxxm:VolcanicAshCloud>
+            </iwxxm:ashCloud>
+            <!-- SFC/FL200 N5130 E16130 N5130 E16230 N5230 E16230 N5230 E16130 MOV SE 15KT -->
+            <iwxxm:ashCloud>
+                <iwxxm:VolcanicAshCloud gml:id="uuid.1f272bcf-ff35-45fe-9206-7963d574c752">
+                    <iwxxm:ashCloudExtent>
+                        <aixm:AirspaceVolume gml:id="uuid.d8a40c1f-5026-47bc-b121-ba2cddbdae94">
+                            <aixm:upperLimit uom="FL">200</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit>GND</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.5d5747e4-da0c-4b2e-8a18-7c2d6c72d76c">
+                                    <gml:patches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>51.50 161.50 51.50 162.50 52.50 162.50 52.50 161.50 51.50 161.50</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:patches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:ashCloudExtent>
+                    <iwxxm:directionOfMotion uom="deg">135</iwxxm:directionOfMotion>
+                    <iwxxm:speedOfMotion uom="[kn_i]">15</iwxxm:speedOfMotion>
+                </iwxxm:VolcanicAshCloud>
+            </iwxxm:ashCloud>
+        </iwxxm:VolcanicAshConditions>
+    </iwxxm:analysis>
+
+    <!-- 23/0700Z -->
+    <iwxxm:analysis>
+        <!-- FL250/350 N5130 E16030 N5130 E16230 N5330 E16230 N5330 E16030 -->
         <iwxxm:VolcanicAshConditions gml:id="uuid.55a27198-f4e9-4a97-8e9d-0af6185f1b43">
-          <!-- FL250/350 N5130 E16030 N5130 E16230 N5330 E16230 N5330 E16030 -->
-          <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="uuid.b8b23d9c-2794-406f-8b8a-6eb5cde393fb">
-              <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="uuid.841fe208-2b26-47f9-a053-a7838a2c334f">
-                  <aixm:upperLimit uom="FL">350</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.ac2ae755-d6cc-480c-87ae-08bba04e3025">
-                      <gml:patches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>51.50 160.50 51.50 162.50 53.50 162.50 53.50 160.50 51.50 160.50</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:patches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:ashCloudExtent>
-            </iwxxm:VolcanicAshCloud>
-          </iwxxm:ashCloud>
-          <!-- SFC/FL180 N4830 E16330 N4830 E16630 N5130 E16630 N5130 E16330 -->
-          <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="uuid.29dff823-5132-42ea-bcda-6e94a6b64983">
-              <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="uuid.d4653c15-dd4f-418e-997a-d0983e7a56ae">
-                  <aixm:upperLimit uom="FL">180</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit>GND</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.4228e3dc-5384-41ce-a89b-ef2f5fe22470">
-                      <gml:patches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>48.50 163.50 48.50 166.50 51.50 166.50 51.50 163.50 48.50 163.50</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:patches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:ashCloudExtent>
-            </iwxxm:VolcanicAshCloud>
-          </iwxxm:ashCloud>
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.7d89ec7f-6266-47d0-8f97-af0cd0905e9a">
+                    <gml:timePosition>2008-09-23T07:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:ashCloud>
+                <iwxxm:VolcanicAshCloud gml:id="uuid.b8b23d9c-2794-406f-8b8a-6eb5cde393fb">
+                    <iwxxm:ashCloudExtent>
+                        <aixm:AirspaceVolume gml:id="uuid.841fe208-2b26-47f9-a053-a7838a2c334f">
+                            <aixm:upperLimit uom="FL">350</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit uom="FL">250</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.ac2ae755-d6cc-480c-87ae-08bba04e3025">
+                                    <gml:patches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>51.50 160.50 51.50 162.50 53.50 162.50 53.50 160.50 51.50 160.50</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:patches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:ashCloudExtent>
+                </iwxxm:VolcanicAshCloud>
+            </iwxxm:ashCloud>
+            <!-- SFC/FL180 N4830 E16330 N4830 E16630 N5130 E16630 N5130 E16330 -->
+            <iwxxm:ashCloud>
+                <iwxxm:VolcanicAshCloud gml:id="uuid.29dff823-5132-42ea-bcda-6e94a6b64983">
+                    <iwxxm:ashCloudExtent>
+                        <aixm:AirspaceVolume gml:id="uuid.d4653c15-dd4f-418e-997a-d0983e7a56ae">
+                            <aixm:upperLimit uom="FL">180</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit>GND</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.4228e3dc-5384-41ce-a89b-ef2f5fe22470">
+                                    <gml:patches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>48.50 163.50 48.50 166.50 51.50 166.50 51.50 163.50 48.50 163.50</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:patches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:ashCloudExtent>
+                </iwxxm:VolcanicAshCloud>
+            </iwxxm:ashCloud>
         </iwxxm:VolcanicAshConditions>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:analysis>
+    </iwxxm:analysis>
 
-  <!-- 23/1300Z -->
-  <iwxxm:analysis>
-    <om:OM_Observation gml:id="uuid.cac25fb2-0765-4fc6-a7db-28f6b31fb389">
-      <om:phenomenonTime>
-        <gml:TimeInstant gml:id="uuid.2e92686b-2a88-44e3-a1ef-fed2cdf71d76">
-          <gml:timePosition>2008-09-23T13:00:00Z</gml:timePosition>
-        </gml:TimeInstant>
-      </om:phenomenonTime>
-      <!-- time at which the results of the observation were made available -->
-      <om:resultTime xlink:href="#ti-2"/>
-      <om:procedure xlink:href="#p-49-2"/>
-      <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
-      <om:featureOfInterest xlink:href="#ssf1"/>
-      <om:result>
+    <!-- 23/1300Z -->
+    <iwxxm:analysis>
+        <!-- SFC/FL270 N4830 E16130 Ð N4830 E16600 Ð N5300 E16600 Ð N5300 E16130  -->
         <iwxxm:VolcanicAshConditions gml:id="uuid.6493c86f-6917-47f0-9749-19d656b1bd1f">
-          <!-- SFC/FL270 N4830 E16130 Ð N4830 E16600 Ð N5300 E16600 Ð N5300 E16130  -->
-          <iwxxm:ashCloud>
-            <iwxxm:VolcanicAshCloud gml:id="uuid.bcc01180-95c0-4ac1-8f13-53bbbfa430b7">
-              <iwxxm:ashCloudExtent>
-                <aixm:AirspaceVolume gml:id="uuid.c35ee5c2-f8bf-43cb-ba9b-24f10fce6678">
-                  <aixm:upperLimit uom="FL">270</aixm:upperLimit>
-                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
-                  <aixm:lowerLimit>GND</aixm:lowerLimit>
-                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
-                  <aixm:horizontalProjection>
-                    <aixm:Surface gml:id="uuid.216a05ac-926a-43aa-b5d2-ae740a6e7b37">
-                      <gml:patches>
-                        <gml:PolygonPatch>
-                          <gml:exterior>
-                            <gml:LinearRing>
-                              <gml:posList>48.50 161.50 48.50 166.00 53.00 166.00 53.00 161.50 48.50 161.50</gml:posList>
-                            </gml:LinearRing>
-                          </gml:exterior>
-                        </gml:PolygonPatch>
-                      </gml:patches>
-                    </aixm:Surface>
-                  </aixm:horizontalProjection>
-                </aixm:AirspaceVolume>
-              </iwxxm:ashCloudExtent>
-            </iwxxm:VolcanicAshCloud>
-          </iwxxm:ashCloud>
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.2e92686b-2a88-44e3-a1ef-fed2cdf71d76">
+                    <gml:timePosition>2008-09-23T13:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:ashCloud>
+                <iwxxm:VolcanicAshCloud gml:id="uuid.bcc01180-95c0-4ac1-8f13-53bbbfa430b7">
+                    <iwxxm:ashCloudExtent>
+                        <aixm:AirspaceVolume gml:id="uuid.c35ee5c2-f8bf-43cb-ba9b-24f10fce6678">
+                            <aixm:upperLimit uom="FL">270</aixm:upperLimit>
+                            <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                            <aixm:lowerLimit>GND</aixm:lowerLimit>
+                            <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                            <aixm:horizontalProjection>
+                                <aixm:Surface gml:id="uuid.216a05ac-926a-43aa-b5d2-ae740a6e7b37">
+                                    <gml:patches>
+                                        <gml:PolygonPatch>
+                                            <gml:exterior>
+                                                <gml:LinearRing>
+                                                    <gml:posList>48.50 161.50 48.50 166.00 53.00 166.00 53.00 161.50 48.50 161.50</gml:posList>
+                                                </gml:LinearRing>
+                                            </gml:exterior>
+                                        </gml:PolygonPatch>
+                                    </gml:patches>
+                                </aixm:Surface>
+                            </aixm:horizontalProjection>
+                        </aixm:AirspaceVolume>
+                    </iwxxm:ashCloudExtent>
+                </iwxxm:VolcanicAshCloud>
+            </iwxxm:ashCloud>
         </iwxxm:VolcanicAshConditions>
-      </om:result>
-    </om:OM_Observation>
-  </iwxxm:analysis>
+    </iwxxm:analysis>
 
-  <!-- 23/1900Z NO VA EXP -->
-  <iwxxm:analysis>
-      <om:OM_Observation gml:id="uuid.54d4c566-606b-4ed5-babf-417a26e00f46">
-          <om:phenomenonTime>
-              <gml:TimeInstant gml:id="uuid.9b7632de-7591-4c3a-a876-99304e3d9d51">
-                  <gml:timePosition>2008-09-23T19:00:00Z</gml:timePosition>
-              </gml:TimeInstant>
-          </om:phenomenonTime>
-          <om:resultTime xlink:href="#ti-2"/>
-          <om:procedure xlink:href="#p-49-2"/>
-          <om:observedProperty xlink:href="http://codes.wmo.int/49-2/observable-property/VolcanicAshConditions"/>
-          <om:featureOfInterest xlink:href="#ssf1"/>
-          <om:result nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
-      </om:OM_Observation>
-  </iwxxm:analysis>
+    <!-- 23/1900Z NO VA EXP -->
+    <iwxxm:analysis>
+        <iwxxm:VolcanicAshConditions>
+            <iwxxm:phenomenonTime>
+                <gml:TimeInstant gml:id="uuid.9b7632de-7591-4c3a-a876-99304e3d9d51">
+                    <gml:timePosition>2008-09-23T19:00:00Z</gml:timePosition>
+                </gml:TimeInstant>
+            </iwxxm:phenomenonTime>
+            <iwxxm:ashCloud nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+        </iwxxm:VolcanicAshConditions>
+    </iwxxm:analysis>
 
-  <!-- Remark -->
-  <iwxxm:remarks>LATEST REP FM KVERT (0120Z) INDICATES ERUPTION HAS CEASED.  TWO DISPERSING VA CLD ARE EVIDENT ON SATELLITE IMAGERY</iwxxm:remarks>
+    <!-- Remark -->
+    <iwxxm:remarks>LATEST REP FM KVERT (0120Z) INDICATES ERUPTION HAS CEASED.  TWO DISPERSING VA CLD ARE EVIDENT ON SATELLITE IMAGERY</iwxxm:remarks>
 
-  <iwxxm:nextAdvisoryEarliestTime>
-    <gml:TimeInstant gml:id="uuid.0480febc-1d6f-49bc-bca3-b54011e2f54f">
-      <gml:timePosition>2008-09-23T07:30:00Z</gml:timePosition>
-    </gml:TimeInstant>
-  </iwxxm:nextAdvisoryEarliestTime>
-  <iwxxm:nextAdvisoryLatestTime xlink:href="#ti23"/>
+    <iwxxm:nextAdvisoryEarliestTime>
+        <gml:TimeInstant gml:id="uuid.0480febc-1d6f-49bc-bca3-b54011e2f54f">
+            <gml:timePosition>2008-09-23T07:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:nextAdvisoryEarliestTime>
+    <iwxxm:nextAdvisoryLatestTime xlink:href="#ti23"/>
 
 </iwxxm:VolcanicAshAdvisory>

--- a/3.0.0RC1/examples/va-advisory-A2-1.xml
+++ b/3.0.0RC1/examples/va-advisory-A2-1.xml
@@ -30,9 +30,9 @@ NXT ADVISORY:               20080923/0730Z
 
 -->
 <iwxxm:VolcanicAshAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-   xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+   xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:metce="http://def.wmo.int/metce/2013"
    xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+   xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
    gml:id="uuid.fb4861a8-0438-4f17-b8a7-efc13de58dec" permissibleUsage="OPERATIONAL">
 
     <iwxxm:issueTime>

--- a/3.0.0RC1/examples/va-advisory-A2-1.xml
+++ b/3.0.0RC1/examples/va-advisory-A2-1.xml
@@ -240,7 +240,7 @@ NXT ADVISORY:               20080923/0730Z
 
     <!-- 23/1900Z NO VA EXP -->
     <iwxxm:analysis>
-        <iwxxm:VolcanicAshConditions>
+        <iwxxm:VolcanicAshConditions gml:id="uuid.e453c86f-6912-47f0-9649-19d656b1bd1f">
             <iwxxm:phenomenonTime>
                 <gml:TimeInstant gml:id="uuid.9b7632de-7591-4c3a-a876-99304e3d9d51">
                     <gml:timePosition>2008-09-23T19:00:00Z</gml:timePosition>

--- a/3.0.0RC1/examples/va-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/va-advisory-translation-failed.xml
@@ -12,10 +12,10 @@ INVALID INVALID INVALID
 
 -->
 <iwxxm:VolcanicAshAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-     xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+     xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:metce="http://def.wmo.int/metce/2013"
      xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+     xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
      gml:id="uuid.074f61f2-3775-4e8b-b60c-17b238d60566" permissibleUsage="OPERATIONAL"
      translatedBulletinID="TTAAiiCCCYYGGgg"
      translatedBulletinReceptionTime="2014-05-15T15:29:00Z"

--- a/3.0.0RC1/examples/va-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/va-advisory-translation-failed.xml
@@ -12,73 +12,60 @@ INVALID INVALID INVALID
 
 -->
 <iwxxm:VolcanicAshAdvisory xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"
-  xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
-  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
-  xmlns:om="http://www.opengis.net/om/2.0" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sam="http://www.opengis.net/sampling/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.aixm.aero/schema/5.1.1 http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd
-  http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"
-  gml:id="uuid.074f61f2-3775-4e8b-b60c-17b238d60566" permissibleUsage="OPERATIONAL"
-  translatedBulletinID="TTAAiiCCCYYGGgg"
-  translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
-  translationCentreDesignator="YUZZ"
-  translationCentreName="Fictional translation centre"
-  translationTime="2014-05-15T15:30:00Z"
-  translationFailedTAC="FVFE01 RJTD 230130
-  VA ADVISORY
+     xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:metce="http://def.wmo.int/metce/2013"
+     xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://icao.int/iwxxm/3.0RC1 http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"
+     gml:id="uuid.074f61f2-3775-4e8b-b60c-17b238d60566" permissibleUsage="OPERATIONAL"
+     translatedBulletinID="TTAAiiCCCYYGGgg"
+     translatedBulletinReceptionTime="2014-05-15T15:29:00Z"
+     translationCentreDesignator="YUZZ"
+     translationCentreName="Fictional translation centre"
+     translationTime="2014-05-15T15:30:00Z"
+     translationFailedTAC="FVFE01 RJTD 230130
+VA ADVISORY
   
-  DTG:                        20080923/0130Z
-  VAAC:                       TOKYO
-  VOLCANO:                    KARYMSKY 1000-13
-  PSN:                        N5403 E15927
-  INVALID INVALID INVALID">
+DTG:                        20080923/0130Z
+VAAC:                       TOKYO
+VOLCANO:                    KARYMSKY 1000-13
+PSN:                        N5403 E15927
+INVALID INVALID INVALID">
 
-  <iwxxm:issueTime>
-      <gml:TimeInstant gml:id="uuid.cb1e8cbb-91c7-4777-b143-ae681d02b09d">
-          <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
-      </gml:TimeInstant>
-  </iwxxm:issueTime>
+    <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="uuid.cb1e8cbb-91c7-4777-b143-ae681d02b09d">
+            <gml:timePosition>2008-09-23T01:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+    </iwxxm:issueTime>
 
-  <iwxxm:issuingVolcanicAshAdvisoryCentre>
-    <aixm:Unit gml:id="uuid.b02269db-1e76-4534-8296-30f950fb3b70">
-      <aixm:timeSlice>
-        <aixm:UnitTimeSlice gml:id="uuid.8c408057-3105-46c2-aec8-31d1611eed39">
-          <gml:validTime>
-            <gml:TimePeriod gml:id="uuid.c958a171-97a6-4d36-92b5-2979cc97a10d">
-              <gml:beginPosition>2008-01-01T00:00:00Z</gml:beginPosition>
-              <gml:endPosition indeterminatePosition="unknown"/>
-            </gml:TimePeriod>
-          </gml:validTime>
-          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:featureLifetime>
-            <gml:TimePeriod gml:id="uuid.071b5cb7-540b-4630-ac0e-3d6100b6337b">
-              <gml:beginPosition>2008-01-01T00:00:00Z</gml:beginPosition>
-              <gml:endPosition indeterminatePosition="unknown"/>
-            </gml:TimePeriod>
-          </aixm:featureLifetime>
-          <aixm:name>TOKYO</aixm:name>
-          <aixm:type>OTHER:VACC</aixm:type>
-        </aixm:UnitTimeSlice>
-      </aixm:timeSlice>
-    </aixm:Unit>
-  </iwxxm:issuingVolcanicAshAdvisoryCentre>
+    <iwxxm:issuingVolcanicAshAdvisoryCentre>
+      <aixm:Unit gml:id="uuid.b02269db-1e76-4534-8296-30f950fb3b70">
+        <aixm:timeSlice>
+          <aixm:UnitTimeSlice gml:id="uuid.8c408057-3105-46c2-aec8-31d1611eed39">
+            <gml:validTime/>
+            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+            <aixm:name>TOKYO</aixm:name>
+            <aixm:type>OTHER:VACC</aixm:type>
+          </aixm:UnitTimeSlice>
+        </aixm:timeSlice>
+      </aixm:Unit>
+    </iwxxm:issuingVolcanicAshAdvisoryCentre>
 
-  <iwxxm:volcano>
-    <metce:EruptingVolcano gml:id="uuid.a0853f49-b98d-41cd-87be-a3ffa6ffd352">
-      <gml:description>FL300 REPORTED</gml:description>
-      <metce:name>KARYMSKY 1000-13</metce:name>
-      <metce:position>
-        <gml:Point gml:id="uuid.4a863495-6f14-4921-9aa8-0162764772ed" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-            <gml:pos>54.03 159.27 1536</gml:pos>
-        </gml:Point>
-      </metce:position>
-      <metce:eruptionDate>2008-09-23T01:30:00Z</metce:eruptionDate>
-    </metce:EruptingVolcano>
-  </iwxxm:volcano>
+    <iwxxm:volcano>
+        <metce:EruptingVolcano gml:id="uuid.a0853f49-b98d-41cd-87be-a3ffa6ffd352">
+            <gml:description>FL300 REPORTED</gml:description>
+            <metce:name>KARYMSKY 1000-13</metce:name>
+            <metce:position>
+                <gml:Point gml:id="uuid.4a863495-6f14-4921-9aa8-0162764772ed" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
+                    <gml:pos>54.03 159.27 1536</gml:pos>
+                </gml:Point>
+            </metce:position>
+            <metce:eruptionDate>2008-09-23T01:30:00Z</metce:eruptionDate>
+        </metce:EruptingVolcano>
+    </iwxxm:volcano>
 
-  <iwxxm:advisoryNumber></iwxxm:advisoryNumber>
-  <iwxxm:informationSource></iwxxm:informationSource>
-  <iwxxm:colourCode nilReason="missing"/>
-  <iwxxm:analysis nilReason="missing"/>
+    <iwxxm:advisoryNumber></iwxxm:advisoryNumber>
+    <iwxxm:informationSource></iwxxm:informationSource>
+    <iwxxm:colourCode nilReason="missing"/>
+    <iwxxm:analysis nilReason="missing"/>
 
 </iwxxm:VolcanicAshAdvisory>

--- a/3.0.0RC1/iwxxm-collect.xsd
+++ b/3.0.0RC1/iwxxm-collect.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema">
-        <import namespace="http://icao.int/iwxxm/3.0RC1" schemaLocation="http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"/>
+        <import namespace="http://icao.int/iwxxm/3.0" schemaLocation="http://schemas.wmo.int/iwxxm/3.0.0RC1/iwxxm.xsd"/>
         <import namespace="http://def.wmo.int/collect/2014" schemaLocation="http://schemas.wmo.int/collect/1.2/collect.xsd"/>
 	<annotation>
 		<documentation>A convenience schema file for validating against IWXXM and WMO Collect.  This is useful for XML validators (such as libxml2) that allow only a single schema location.</documentation>

--- a/3.0.0RC1/iwxxm.xsd
+++ b/3.0.0RC1/iwxxm.xsd
@@ -8,7 +8,6 @@
 	<include schemaLocation="sigmet.xsd"></include>
 	<include schemaLocation="taf.xsd"></include>
 	<include schemaLocation="metarSpeci.xsd"></include>
-	<import namespace="http://www.opengis.net/samplingSpatial/2.0" schemaLocation="http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>The ICAO Meteorological Information Exchange Model (IWXXM) package, including METAR, SPECI, TAF, and other reports as defined in ICAO Annex 3, Amendment 76.  IWXXM reports are essential operational meteorology products used to enable safe and efficient air travel worldwide.

--- a/3.0.0RC1/iwxxm.xsd
+++ b/3.0.0RC1/iwxxm.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="measures.xsd"></include>
 	<include schemaLocation="common.xsd"></include>
 	<include schemaLocation="volcanicAshAdvisory.xsd"></include>
@@ -8,6 +8,7 @@
 	<include schemaLocation="sigmet.xsd"></include>
 	<include schemaLocation="taf.xsd"></include>
 	<include schemaLocation="metarSpeci.xsd"></include>
+	<import namespace="http://www.opengis.net/samplingSpatial/2.0" schemaLocation="http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>The ICAO Meteorological Information Exchange Model (IWXXM) package, including METAR, SPECI, TAF, and other reports as defined in ICAO Annex 3, Amendment 76.  IWXXM reports are essential operational meteorology products used to enable safe and efficient air travel worldwide.

--- a/3.0.0RC1/measures.xsd
+++ b/3.0.0RC1/measures.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>Common measured quantities used across multiple packages.

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -23,8 +23,8 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 			<extension base="iwxxm:ReportType">
 				<sequence>
 				    <element name="aerodrome" type="iwxxm:AirportHeliportPropertyType"/>
+				    <element name="issueTime" type="gml:TimeInstantPropertyType"/>
 				    <element name="observationTime" type="gml:TimeInstantPropertyType"/>
-				    <element name="observationLocation" type="gml:PointPropertyType"/>
 					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -37,19 +37,10 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The time at which phenomena were observed.  This may differ from the times reported for forecast conditions</documentation>
 						</annotation>
 					</element>
-					<element name="observation">
+					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationType">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:MeteorologicalAerodromeObservation"></element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element nillable="true" name="trendForecast" minOccurs="0" maxOccurs="3">
 						<annotation>

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>METAR and SPECI reporting constructs as defined in ICAO Annex 3 / WMO No. 49-2.
@@ -23,12 +22,15 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
-					<element name="observation" type="om:OM_ObservationPropertyType">
+				    <element name="aerodrome" type="iwxxm:AirportHeliportPropertyType"/>
+				    <element name="observationTime" type="gml:TimeInstantPropertyType"/>
+				    <element name="observationLocation" type="gml:PointPropertyType"/>
+					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="trendForecast" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="3">
+					<element nillable="true" name="trendForecast" type="iwxxm:MeteorologicalAerodromeTrendForecastPropertyType" minOccurs="0" maxOccurs="3">
 						<annotation>
 							<documentation>The process that results in a trend forecast.  When no change is expected to occur during a forecast period ("NOSIG") this is indicated by a single missing trend forecast with a nil reason of noSignificantChange</documentation>
 						</annotation>
@@ -118,17 +120,18 @@ See ICAO Annex 3 / WMO No. 49-2 Table A3-2</documentation>
 		<attributeGroup ref="gml:AssociationAttributeGroup"></attributeGroup>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"></attributeGroup>
 	</complexType>
-	<element name="MeteorologicalAerodromeTrendForecastRecord" type="iwxxm:MeteorologicalAerodromeTrendForecastRecordType" substitutionGroup="gml:AbstractGML">
+	<element name="MeteorologicalAerodromeTrendForecast" type="iwxxm:MeteorologicalAerodromeTrendForecastType" substitutionGroup="gml:AbstractGML">
 		<annotation>
 			<documentation>A specialized Record type containing meteorological conditions for trend forecasting at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeForecastRecord which is reported on a TAF - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
 
 When no clouds of operational significance or no weather of operational significance is predicted, the NothingOfOperationalSignificance nilReason should be used for the cloud or presentWeather association.  When no clouds were detected by the automatic observing system, the NotDetectedByAutoSystem nilReason should be used for the cloud association.</documentation>
 		</annotation>
 	</element>
-	<complexType name="MeteorologicalAerodromeTrendForecastRecordType">
+	<complexType name="MeteorologicalAerodromeTrendForecastType">
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility reported in a trend forecast.
@@ -153,7 +156,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 					<element nillable="true" name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
-							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeTrendForecastRecord</documentation>
+							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeTrendForecast</documentation>
 						</annotation>
 					</element>
 				</sequence>
@@ -172,21 +175,21 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 			</extension>
 		</complexContent>
 	</complexType>
-	<complexType name="MeteorologicalAerodromeTrendForecastRecordPropertyType">
+	<complexType name="MeteorologicalAerodromeTrendForecastPropertyType">
 		<sequence minOccurs="0">
-			<element ref="iwxxm:MeteorologicalAerodromeTrendForecastRecord"></element>
+			<element ref="iwxxm:MeteorologicalAerodromeTrendForecast"></element>
 		</sequence>
 		<attributeGroup ref="gml:AssociationAttributeGroup"></attributeGroup>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"></attributeGroup>
 	</complexType>
-	<element name="MeteorologicalAerodromeObservationRecord" type="iwxxm:MeteorologicalAerodromeObservationRecordType" substitutionGroup="gml:AbstractGML">
+	<element name="MeteorologicalAerodromeObservation" type="iwxxm:MeteorologicalAerodromeObservationType" substitutionGroup="gml:AbstractGML">
 		<annotation>
 			<documentation>A specialized Record type containing meteorological conditions observed at an aerodrome.
 
 When no clouds of operational significance or no weather of operational significance is observed, the NothingOfOperationalSignificance nilReason is used for the cloud or presentWeather association. When no clouds were detected by the automatic observing system, the NotDetectedByAutoSystem nilReason is used for the cloud association.</documentation>
 		</annotation>
 	</element>
-	<complexType name="MeteorologicalAerodromeObservationRecordType">
+	<complexType name="MeteorologicalAerodromeObservationType">
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
@@ -241,7 +244,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 					<element name="runwayState" type="iwxxm:AerodromeRunwayStatePropertyType" minOccurs="0" maxOccurs="unbounded"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
-							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeObservationRecord</documentation>
+							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeObservation</documentation>
 						</annotation>
 					</element>
 				</sequence>
@@ -255,9 +258,9 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 			</extension>
 		</complexContent>
 	</complexType>
-	<complexType name="MeteorologicalAerodromeObservationRecordPropertyType">
+	<complexType name="MeteorologicalAerodromeObservationPropertyType">
 		<sequence minOccurs="0">
-			<element ref="iwxxm:MeteorologicalAerodromeObservationRecord"></element>
+			<element ref="iwxxm:MeteorologicalAerodromeObservation"></element>
 		</sequence>
 		<attributeGroup ref="gml:AssociationAttributeGroup"></attributeGroup>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"></attributeGroup>
@@ -780,7 +783,7 @@ See WMO No. 306 Vol I.2 FM 94 BUFR code-table 0 20 018 "Tendency of runway visua
 	</simpleType>
 	<simpleType name="MeteorologicalAerodromeReportStatusType">
 		<annotation>
-			<documentation>The status of a MeteorologicalAerodromeObservationReport (e.g., a normal issuance, correction of an earlier report, etc.)</documentation>
+			<documentation>The status of a MeteorologicalAerodromeObservation (e.g., a normal issuance, correction of an earlier report, etc.)</documentation>
 		</annotation>
 		<restriction base="string">
 			<enumeration value="NORMAL">

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -22,18 +22,48 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
-				    <element name="aerodrome" type="iwxxm:AirportHeliportPropertyType"/>
-				    <element name="issueTime" type="gml:TimeInstantPropertyType"/>
-				    <element name="observationTime" type="gml:TimeInstantPropertyType"/>
-					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
+					<element name="aerodrome" type="iwxxm:AirportHeliportPropertyType">
+						<annotation>
+							<documentation>The aerodrome location for this report</documentation>
+						</annotation>
+					</element>
+					<element name="issueTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which this report was issued</documentation>
+						</annotation>
+					</element>
+					<element name="observationTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which phenomena were observed.  This may differ from the times reported for forecast conditions</documentation>
+						</annotation>
+					</element>
+					<element name="observation">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:MeteorologicalAerodromeObservation"></element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
-					<element nillable="true" name="trendForecast" type="iwxxm:MeteorologicalAerodromeTrendForecastPropertyType" minOccurs="0" maxOccurs="3">
+					<element nillable="true" name="trendForecast" minOccurs="0" maxOccurs="3">
 						<annotation>
 							<documentation>The process that results in a trend forecast.  When no change is expected to occur during a forecast period ("NOSIG") this is indicated by a single missing trend forecast with a nil reason of noSignificantChange</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:MeteorologicalAerodromeTrendForecast"></element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
 				</sequence>
 				<attribute use="required" name="status" type="iwxxm:MeteorologicalAerodromeReportStatusType">
@@ -73,7 +103,7 @@ See ICAO Annex 3 / WMO No. 49-2 Table A3-2</documentation>
 		<complexContent>
 			<extension base="iwxxm:MeteorologicalAerodromeObservationReportType">
 				<sequence>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SPECI</documentation>
 						</annotation>
@@ -104,7 +134,7 @@ See ICAO Annex 3 / WMO No. 49-2 Table A3-2</documentation>
 		<complexContent>
 			<extension base="iwxxm:MeteorologicalAerodromeObservationReportType">
 				<sequence>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element METAR</documentation>
 						</annotation>
@@ -122,7 +152,7 @@ See ICAO Annex 3 / WMO No. 49-2 Table A3-2</documentation>
 	</complexType>
 	<element name="MeteorologicalAerodromeTrendForecast" type="iwxxm:MeteorologicalAerodromeTrendForecastType" substitutionGroup="gml:AbstractGML">
 		<annotation>
-			<documentation>A specialized Record type containing meteorological conditions for trend forecasting at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeForecastRecord which is reported on a TAF - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
+			<documentation>Meteorological conditions for trend forecasting at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeForecast which is reported on a TAF - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
 
 When no clouds of operational significance or no weather of operational significance is predicted, the NothingOfOperationalSignificance nilReason should be used for the cloud or presentWeather association.  When no clouds were detected by the automatic observing system, the NotDetectedByAutoSystem nilReason should be used for the cloud association.</documentation>
 		</annotation>
@@ -131,7 +161,6 @@ When no clouds of operational significance or no weather of operational signific
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility reported in a trend forecast.
@@ -154,7 +183,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindTrendForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element nillable="true" name="forecastWeather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeTrendForecast</documentation>
 						</annotation>
@@ -184,7 +213,7 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 	</complexType>
 	<element name="MeteorologicalAerodromeObservation" type="iwxxm:MeteorologicalAerodromeObservationType" substitutionGroup="gml:AbstractGML">
 		<annotation>
-			<documentation>A specialized Record type containing meteorological conditions observed at an aerodrome.
+			<documentation>Meteorological conditions observed at an aerodrome.
 
 When no clouds of operational significance or no weather of operational significance is observed, the NothingOfOperationalSignificance nilReason is used for the cloud or presentWeather association. When no clouds were detected by the automatic observing system, the NotDetectedByAutoSystem nilReason is used for the cloud association.</documentation>
 		</annotation>
@@ -242,7 +271,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 					<element name="windShear" type="iwxxm:AerodromeWindShearPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="seaState" type="iwxxm:AerodromeSeaStatePropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="runwayState" type="iwxxm:AerodromeRunwayStatePropertyType" minOccurs="0" maxOccurs="unbounded"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeObservation</documentation>
 						</annotation>
@@ -323,7 +352,7 @@ WMO 306:
 Table 0366</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeRunwayState</documentation>
 				</annotation>
@@ -394,7 +423,7 @@ Section 4.3.6.6</documentation>
 To report a mean RVR of at least 2000 metres, mean RVR is reported as 2000 metres and the operator is reported as "above".  To report a mean RVR of less than 50 metres, mean RVR is reported as 50 metres and the operator is reported as "below".  When no operator is reported, mean RVR represents an exact value with identical semantics to other measured quantities</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeRunwayVisualRange</documentation>
 				</annotation>
@@ -458,7 +487,7 @@ WMO 306:
 Table 3700</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeSeaState</documentation>
 				</annotation>
@@ -483,7 +512,7 @@ Table 3700</documentation>
 					<documentation>The specific runway(s) affected by wind shear at this aerodrome. No specific runways are reported when all runways are affected by wind shear</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeWindShear</documentation>
 				</annotation>
@@ -531,7 +560,7 @@ When the sky is obscured and the value of the vertical visibility cannot be dete
 					</complexContent>
 				</complexType>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeObservedClouds</documentation>
 				</annotation>
@@ -631,7 +660,7 @@ Section 4.1.5.2b</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeSurfaceWind</documentation>
 				</annotation>
@@ -716,7 +745,7 @@ Direction of minimum visibility shall be given in degrees from true North. Plane
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeHorizontalVisibility</documentation>
 				</annotation>
@@ -783,7 +812,7 @@ See WMO No. 306 Vol I.2 FM 94 BUFR code-table 0 20 018 "Tendency of runway visua
 	</simpleType>
 	<simpleType name="MeteorologicalAerodromeReportStatusType">
 		<annotation>
-			<documentation>The status of a MeteorologicalAerodromeObservation (e.g., a normal issuance, correction of an earlier report, etc.)</documentation>
+			<documentation>The report issuance status (e.g., a normal issuance, correction of an earlier report, etc.)</documentation>
 		</annotation>
 		<restriction base="string">
 			<enumeration value="NORMAL">

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -37,7 +37,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The time at which phenomena were observed.  This may differ from the times reported for forecast conditions</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationType">
+					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>
@@ -172,7 +172,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 						</annotation>
 					</element>
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindTrendForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element nillable="true" name="forecastWeather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
+					<element nillable="true" name="forecastWeather" type="iwxxm:AerodromeForecastWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
@@ -248,7 +248,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindPropertyType"></element>
 					<element name="visibility" type="iwxxm:AerodromeHorizontalVisibilityPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="rvr" type="iwxxm:AerodromeRunwayVisualRangePropertyType" minOccurs="0" maxOccurs="4"></element>
-					<element nillable="true" name="presentWeather" type="iwxxm:AerodromePresentWeatherType" minOccurs="0" maxOccurs="3"></element>
+					<element nillable="true" name="presentWeather" type="iwxxm:AerodromePresentWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" minOccurs="0" maxOccurs="1">
 						<complexType>
 							<complexContent>
@@ -258,7 +258,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 							</complexContent>
 						</complexType>
 					</element>
-					<element name="recentWeather" type="iwxxm:AerodromeRecentWeatherType" minOccurs="0" maxOccurs="3"></element>
+					<element name="recentWeather" type="iwxxm:AerodromeRecentWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
 					<element name="windShear" type="iwxxm:AerodromeWindShearPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="seaState" type="iwxxm:AerodromeSeaStatePropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="runwayState" type="iwxxm:AerodromeRunwayStatePropertyType" minOccurs="0" maxOccurs="unbounded"></element>
@@ -297,7 +297,7 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 					<documentation>The runway to which the conditions apply.  The runway may be missing in cases where all runways are closed due to snow</documentation>
 				</annotation>
 			</element>
-			<element name="depositType" type="iwxxm:RunwayDepositsType" minOccurs="0" maxOccurs="1">
+			<element name="depositType" type="iwxxm:RunwayDepositsPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The type of runway deposit, such as damp conditions, wet snow, or ice.
 
@@ -305,7 +305,7 @@ WMO 306:
 Table 0919</documentation>
 				</annotation>
 			</element>
-			<element name="contamination" type="iwxxm:RunwayContaminationType" minOccurs="0" maxOccurs="1">
+			<element name="contamination" type="iwxxm:RunwayContaminationPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Proportion of runway surface that is contaminated - usually expressed as a percentage of the total runway area.
 
@@ -323,7 +323,7 @@ See WMO No. 306:
 					</appinfo>
 				</annotation>
 			</element>
-			<element nillable="true" name="depthOfDeposit" type="iwxxm:DistanceWithNilReasonType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="depthOfDeposit" type="iwxxm:DistanceWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Depth of deposit on the surface of the runway.
 
@@ -335,7 +335,7 @@ See WMO No. 306 WMO Code table 1079.</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientType" minOccurs="0" maxOccurs="1">
+			<element name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The estimated surface friction or braking action for the affected runway.  When braking conditions are not reported and/or the runway is not operational estimatedSurfaceFrictionOrBrakingAction will not be reported.
 
@@ -467,7 +467,7 @@ Section 4.8.1.5a</documentation>
 Significant wave height shall be reported in meters ("m").</documentation>
 				</annotation>
 			</element>
-			<element name="seaState" type="iwxxm:SeaSurfaceStateType" minOccurs="0" maxOccurs="1">
+			<element name="seaState" type="iwxxm:SeaSurfaceStatePropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The state of the sea observed by aeronautical meteorological stations established on offshore structures in support of helicopter operations
 
@@ -528,7 +528,7 @@ Table 3700</documentation>
 	</element>
 	<complexType name="AerodromeObservedCloudsType">
 		<sequence>
-			<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The reported vertical visibility.  Vertical visibility is defined as the vertical visual range into an obscuring medium.
 

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -152,6 +152,11 @@ When no clouds of operational significance or no weather of operational signific
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility reported in a trend forecast.
@@ -172,7 +177,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 						</annotation>
 					</element>
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindTrendForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element nillable="true" name="forecastWeather" type="iwxxm:AerodromeForecastWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
+					<element nillable="true" name="forecastWeather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
@@ -248,7 +253,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindPropertyType"></element>
 					<element name="visibility" type="iwxxm:AerodromeHorizontalVisibilityPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="rvr" type="iwxxm:AerodromeRunwayVisualRangePropertyType" minOccurs="0" maxOccurs="4"></element>
-					<element nillable="true" name="presentWeather" type="iwxxm:AerodromePresentWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
+					<element nillable="true" name="presentWeather" type="iwxxm:AerodromePresentWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" minOccurs="0" maxOccurs="1">
 						<complexType>
 							<complexContent>
@@ -258,7 +263,7 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 							</complexContent>
 						</complexType>
 					</element>
-					<element name="recentWeather" type="iwxxm:AerodromeRecentWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
+					<element name="recentWeather" type="iwxxm:AerodromeRecentWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element name="windShear" type="iwxxm:AerodromeWindShearPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="seaState" type="iwxxm:AerodromeSeaStatePropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="runwayState" type="iwxxm:AerodromeRunwayStatePropertyType" minOccurs="0" maxOccurs="unbounded"></element>
@@ -297,7 +302,7 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 					<documentation>The runway to which the conditions apply.  The runway may be missing in cases where all runways are closed due to snow</documentation>
 				</annotation>
 			</element>
-			<element name="depositType" type="iwxxm:RunwayDepositsPropertyType" minOccurs="0" maxOccurs="1">
+			<element name="depositType" type="iwxxm:RunwayDepositsType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The type of runway deposit, such as damp conditions, wet snow, or ice.
 
@@ -305,7 +310,7 @@ WMO 306:
 Table 0919</documentation>
 				</annotation>
 			</element>
-			<element name="contamination" type="iwxxm:RunwayContaminationPropertyType" minOccurs="0" maxOccurs="1">
+			<element name="contamination" type="iwxxm:RunwayContaminationType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Proportion of runway surface that is contaminated - usually expressed as a percentage of the total runway area.
 
@@ -323,7 +328,7 @@ See WMO No. 306:
 					</appinfo>
 				</annotation>
 			</element>
-			<element nillable="true" name="depthOfDeposit" type="iwxxm:DistanceWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="depthOfDeposit" type="iwxxm:DistanceWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Depth of deposit on the surface of the runway.
 
@@ -335,7 +340,7 @@ See WMO No. 306 WMO Code table 1079.</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientPropertyType" minOccurs="0" maxOccurs="1">
+			<element name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The estimated surface friction or braking action for the affected runway.  When braking conditions are not reported and/or the runway is not operational estimatedSurfaceFrictionOrBrakingAction will not be reported.
 
@@ -467,7 +472,7 @@ Section 4.8.1.5a</documentation>
 Significant wave height shall be reported in meters ("m").</documentation>
 				</annotation>
 			</element>
-			<element name="seaState" type="iwxxm:SeaSurfaceStatePropertyType" minOccurs="0" maxOccurs="1">
+			<element name="seaState" type="iwxxm:SeaSurfaceStateType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The state of the sea observed by aeronautical meteorological stations established on offshore structures in support of helicopter operations
 
@@ -528,7 +533,7 @@ Table 3700</documentation>
 	</element>
 	<complexType name="AerodromeObservedCloudsType">
 		<sequence>
-			<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="verticalVisibility" type="iwxxm:LengthWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The reported vertical visibility.  Vertical visibility is defined as the vertical visual range into an obscuring medium.
 

--- a/3.0.0RC1/rule/iwxxm-collect.sch
+++ b/3.0.0RC1/rule/iwxxm-collect.sch
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <sch:title>Schematron validation</sch:title>
-   <sch:ns prefix="collect" uri="http://def.wmo.int/collect/2014"/>
-   <sch:ns prefix="iwxxm" uri="http://icao.int/iwxxm/3.0RC1"/>
+   <sch:ns prefix="iwxxm" uri="http://icao.int/iwxxm/3.0"/>
    <sch:ns prefix="sf" uri="http://www.opengis.net/sampling/2.0"/>
    <sch:ns prefix="sams" uri="http://www.opengis.net/samplingSpatial/2.0"/>
    <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
@@ -10,6 +9,7 @@
    <sch:ns prefix="om" uri="http://www.opengis.net/om/2.0"/>
    <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
    <sch:ns prefix="aixm" uri="http://www.aixm.aero/schema/5.1.1"/>
+   <sch:ns prefix="collect" uri="http://def.wmo.int/collect/2014"/>
    <sch:pattern id="COLLECT.MB1">
       <sch:rule context="//collect:MeteorologicalBulletin">
          <sch:assert test="count(distinct-values(for $item in //collect:meteorologicalInformation/child::node() return(node-name($item))))eq 1">COLLECT.MB1: All meteorologicalInformation instances in MeteorologicalBulletin must be of the same type</sch:assert>
@@ -95,68 +95,63 @@
          <sch:assert test="(if( @allRunways eq 'true' ) then( empty(iwxxm:runway) ) else true())">METAR_SPECI.AWS1: When all runways are affected by wind shear, no specific runways should be reported</sch:assert>
       </sch:rule>
    </sch:pattern>
-   <sch:pattern id="METAR_SPECI.MATFR5">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
-         <sch:assert test="(if( @changeIndicator eq 'NO_SIGNIFICANT_CHANGES' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator) and empty(iwxxm:clouds) and empty(iwxxm:forecastWeather) and empty(iwxxm:cloudAndVisibilityOK)) else (true()))">METAR_SPECI.MATFR5: prevailingVisibility, prevailingVisibilityOperator, clouds, forecastWeather and cloudAndVisibilityOK should be absent when changeIndicator equals 'NO_SIGNIFICANT_CHANGES'</sch:assert>
-      </sch:rule>
-   </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MATFR1: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:forecastWeather)) else (true()))">METAR_SPECI.MATFR2: forecastWeather should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator)) else (true()))">METAR_SPECI.MATFR4: prevailingVisibility and prevailingVisibilityOperator should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">METAR_SPECI.MATFR3: prevailingVisibility shall be reported in metres (m).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec6">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:airTemperature) and (not(exists(iwxxm:airTemperature/@xsi:nil)) or iwxxm:airTemperature/@xsi:nil != 'true')) then (iwxxm:airTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec6: airTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MAORec4: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:presentWeather) else true())">METAR_SPECI.MAORec3: presentWeather should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:rvr) else true())">METAR_SPECI.MAORec2: rvr should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:visibility) else true())">METAR_SPECI.MAORec1: visibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec7">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:dewpointTemperature) and (not(exists(iwxxm:dewpointTemperature/@xsi:nil)) or iwxxm:dewpointTemperature/@xsi:nil != 'true')) then (iwxxm:dewpointTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec7: dewpointTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec8">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:qnh) and (not(exists(iwxxm:qnh/@xsi:nil)) or iwxxm:qnh/@xsi:nil != 'true')) then (iwxxm:qnh/@uom = 'hPa') else true())">METAR_SPECI.MAORec8: qnh shall be reported in hectopascals (hPa).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec5">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if((exists(iwxxm:visibility)) and (iwxxm:visibility//iwxxm:prevailingVisibility/number(text()) lt 1500) and (iwxxm:visibility//iwxxm:prevailingVisibility/@uom eq 'm')) then (exists(iwxxm:rvr)) else true())">METAR_SPECI.MAORec5: Table A3-2 Note 7 states: "To be included if visibility or RVR &amp;lt; 1500 m; for up to a maximum of four runways". This is interpreted to mean that if the prevailing visibility is below 1500 meters, RVR should always be included</sch:assert>
       </sch:rule>
    </sch:pattern>
@@ -221,22 +216,22 @@
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:cloud) else true())">TAF.MAFR2: cloud should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:prevailingVisibility) else true())">TAF.MAFR1: prevailingVisibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:weather) else true())">TAF.MAFR3: weather should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">TAF.MAFR4: prevailingVisibility shall be reported in metres (m).</sch:assert>
       </sch:rule>
    </sch:pattern>
@@ -560,15 +555,15 @@
          <sch:assert test="(if(exists(iwxxm:base) and (not(exists(iwxxm:base/@xsi:nil)) or iwxxm:base/@xsi:nil != 'true')) then ((iwxxm:base/@uom = 'm') or (iwxxm:base/@uom = '[ft_i]')) else true())">COMMON.CL1: base shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
       </sch:rule>
    </sch:pattern>
+   <sch:pattern id="COMMON.Report5">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
+      </sch:rule>
+   </sch:pattern>
    <sch:pattern id="COMMON.Report4">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
       </sch:rule>
-   </sch:pattern>
-   <sch:pattern id="COMMON.Report5">
-     <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
-       <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
-     </sch:rule>
    </sch:pattern>
    <sch:pattern id="COMMON.Report2">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">

--- a/3.0.0RC1/rule/iwxxm.sch
+++ b/3.0.0RC1/rule/iwxxm.sch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <sch:title>Schematron validation</sch:title>
-   <sch:ns prefix="iwxxm" uri="http://icao.int/iwxxm/3.0RC1"/>
+   <sch:ns prefix="iwxxm" uri="http://icao.int/iwxxm/3.0"/>
    <sch:ns prefix="sf" uri="http://www.opengis.net/sampling/2.0"/>
    <sch:ns prefix="sams" uri="http://www.opengis.net/samplingSpatial/2.0"/>
    <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
@@ -89,68 +89,63 @@
          <sch:assert test="(if( @allRunways eq 'true' ) then( empty(iwxxm:runway) ) else true())">METAR_SPECI.AWS1: When all runways are affected by wind shear, no specific runways should be reported</sch:assert>
       </sch:rule>
    </sch:pattern>
-   <sch:pattern id="METAR_SPECI.MATFR5">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
-         <sch:assert test="(if( @changeIndicator eq 'NO_SIGNIFICANT_CHANGES' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator) and empty(iwxxm:clouds) and empty(iwxxm:forecastWeather) and empty(iwxxm:cloudAndVisibilityOK)) else (true()))">METAR_SPECI.MATFR5: prevailingVisibility, prevailingVisibilityOperator, clouds, forecastWeather and cloudAndVisibilityOK should be absent when changeIndicator equals 'NO_SIGNIFICANT_CHANGES'</sch:assert>
-      </sch:rule>
-   </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MATFR1: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:forecastWeather)) else (true()))">METAR_SPECI.MATFR2: forecastWeather should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if( @cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:prevailingVisibility) and empty(iwxxm:prevailingVisibilityOperator)) else (true()))">METAR_SPECI.MATFR4: prevailingVisibility and prevailingVisibilityOperator should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MATFR3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeTrendForecast">
          <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">METAR_SPECI.MATFR3: prevailingVisibility shall be reported in metres (m).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec6">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:airTemperature) and (not(exists(iwxxm:airTemperature/@xsi:nil)) or iwxxm:airTemperature/@xsi:nil != 'true')) then (iwxxm:airTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec6: airTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK eq 'true' ) then (empty(iwxxm:cloud)) else (true()))">METAR_SPECI.MAORec4: clouds should be absent when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:presentWeather) else true())">METAR_SPECI.MAORec3: presentWeather should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:rvr) else true())">METAR_SPECI.MAORec2: rvr should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(@cloudAndVisibilityOK='true') then empty(iwxxm:visibility) else true())">METAR_SPECI.MAORec1: visibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec7">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:dewpointTemperature) and (not(exists(iwxxm:dewpointTemperature/@xsi:nil)) or iwxxm:dewpointTemperature/@xsi:nil != 'true')) then (iwxxm:dewpointTemperature/@uom = 'Cel') else true())">METAR_SPECI.MAORec7: dewpointTemperature shall be reported in degrees Celsius (Cel).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec8">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if(exists(iwxxm:qnh) and (not(exists(iwxxm:qnh/@xsi:nil)) or iwxxm:qnh/@xsi:nil != 'true')) then (iwxxm:qnh/@uom = 'hPa') else true())">METAR_SPECI.MAORec8: qnh shall be reported in hectopascals (hPa).</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MAORec5">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservationRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeObservation">
          <sch:assert test="(if((exists(iwxxm:visibility)) and (iwxxm:visibility//iwxxm:prevailingVisibility/number(text()) lt 1500) and (iwxxm:visibility//iwxxm:prevailingVisibility/@uom eq 'm')) then (exists(iwxxm:rvr)) else true())">METAR_SPECI.MAORec5: Table A3-2 Note 7 states: "To be included if visibility or RVR &amp;lt; 1500 m; for up to a maximum of four runways". This is interpreted to mean that if the prevailing visibility is below 1500 meters, RVR should always be included</sch:assert>
       </sch:rule>
    </sch:pattern>
@@ -215,22 +210,22 @@
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR2">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:cloud) else true())">TAF.MAFR2: cloud should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR1">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:prevailingVisibility) else true())">TAF.MAFR1: prevailingVisibility should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR3">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(@cloudAndVisibilityOK = 'true') then empty(iwxxm:weather) else true())">TAF.MAFR3: weather should not be reported when cloudAndVisibilityOK is true</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.MAFR4">
-      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecastRecord">
+      <sch:rule context="//iwxxm:MeteorologicalAerodromeForecast">
          <sch:assert test="(if(exists(iwxxm:prevailingVisibility) and (not(exists(iwxxm:prevailingVisibility/@xsi:nil)) or iwxxm:prevailingVisibility/@xsi:nil != 'true')) then (iwxxm:prevailingVisibility/@uom = 'm') else true())">TAF.MAFR4: prevailingVisibility shall be reported in metres (m).</sch:assert>
       </sch:rule>
    </sch:pattern>
@@ -554,17 +549,17 @@
          <sch:assert test="(if(exists(iwxxm:base) and (not(exists(iwxxm:base/@xsi:nil)) or iwxxm:base/@xsi:nil != 'true')) then ((iwxxm:base/@uom = 'm') or (iwxxm:base/@uom = '[ft_i]')) else true())">COMMON.CL1: base shall be reported in metres (m) or feet ([ft_i]).</sch:assert>
       </sch:rule>
    </sch:pattern>
+   <sch:pattern id="COMMON.Report5">
+      <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
+         <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
+      </sch:rule>
+   </sch:pattern>
    <sch:pattern id="COMMON.Report4">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="sum( //iwxxm:extension/.//text()/string-length(.) ) +sum( //iwxxm:extension/.//element()/( (string-length( name() ) * 2 ) + 5 ) ) +sum( //iwxxm:extension/.//@*/( 1 + string-length(name()) + 3 + string-length(.) ) ) +sum( //iwxxm:extension/.//comment()/( string-length( . ) + 7 ) ) lt 5000">COMMON.Report4: Total size of extension content must not exceed 5000 characters per report</sch:assert>
       </sch:rule>
    </sch:pattern>
-  <sch:pattern id="COMMON.Report5">
-    <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
-      <sch:assert test="if( //@gml:id[not(matches(.,'uuid\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'))]) then false() else true()">COMMON.Report5: All gml:ids in IWXXM reports must be UUID version 4</sch:assert>
-    </sch:rule>
-  </sch:pattern>
-  <sch:pattern id="COMMON.Report2">
+   <sch:pattern id="COMMON.Report2">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI|//iwxxm:TAF|//iwxxm:SIGMET|//iwxxm:VolcanicAshSIGMET|//iwxxm:TropicalCycloneSIGMET|//iwxxm:AIRMET|//iwxxm:TropicalCycloneAdvisory|//iwxxm:VolcanicAshAdvisory">
          <sch:assert test="(if(@permissibleUsage eq 'OPERATIONAL') then( not( exists(@permissibleUsageReason))) else(true()))">COMMON.Report2: Operational reports should not include a permissibleUsageReason</sch:assert>
       </sch:rule>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -20,12 +20,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="member" type="iwxxm:SIGMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
-					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
-						<annotation>
-							<documentation>The time at which meteorological phenomena occur</documentation>
-						</annotation>
-					</element>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
+				    <element name="member" type="iwxxm:SIGMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMETEvolvingConditionCollection</documentation>
@@ -148,7 +148,7 @@ YUDD SIGMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous SIGMET that is cancelled by this SIGMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonPropertyType">
+					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonType">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.
 
@@ -204,7 +204,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>This element refers to the expected direction of movement which the phenomenon is moving towards, .e.g, "moving east". When no movement is expected, this is a http://www.opengis.net/def/nil/OGC/0/inapplicable nilReason and the speedOfMotion will be 0.
 
@@ -272,7 +272,7 @@ speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]
 		<complexContent>
 			<extension base="iwxxm:SIGMETType">
 				<sequence>
-					<element name="tropicalCyclone" type="metce:TropicalCyclonePropertyPropertyType">
+					<element name="tropicalCyclone" type="metce:TropicalCyclonePropertyType">
 						<annotation>
 							<documentation>The tropical cyclone being reported in this SIGMET.
 
@@ -304,7 +304,7 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 		<complexContent>
 			<extension base="iwxxm:SIGMETType">
 				<sequence>
-					<element name="eruptingVolcano" type="metce:VolcanoPropertyPropertyType">
+					<element name="eruptingVolcano" type="metce:VolcanoPropertyType">
 						<annotation>
 							<documentation>The volcano that is erupting</documentation>
 						</annotation>
@@ -334,6 +334,11 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
 					<element name="member" type="iwxxm:SIGMETPositionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -148,21 +148,21 @@ YUDD SIGMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous SIGMET that is cancelled by this SIGMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonType">
+					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonPropertyType">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.
 
 The expected end of occurrence of volcanic ash ("NO VA EXP") is indicated with a missing SIGMET phenomenon with a nil reason of nothingOfOperationalSignificance</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:SIGMETEvolvingConditionCollectionType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:SIGMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>SIGMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  All combinations of observations and forecasts of meteorological conditions, including changing conditions, are represented by their own SIGMETEvolvingMeteorologicalCondition.
 
 Each analysis has a single EvolvingMeteorologicalCondition as its result.  </documentation>
 						</annotation>
 					</element>
-					<element name="forecastPositionAnalysis" type="iwxxm:SIGMETPositionCollectionType" minOccurs="0" maxOccurs="1">
+					<element name="forecastPositionAnalysis" type="iwxxm:SIGMETPositionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>One or more forecast positions at the end of the valid period - one for each phenomenon area within an FIR.  These are modeled as a single OM_Observation sub-type with a feature collection result due to the shared time and other observation metadata for all forecast positions.</documentation>
 						</annotation>
@@ -204,7 +204,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>This element refers to the expected direction of movement which the phenomenon is moving towards, .e.g, "moving east". When no movement is expected, this is a http://www.opengis.net/def/nil/OGC/0/inapplicable nilReason and the speedOfMotion will be 0.
 
@@ -272,7 +272,7 @@ speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]
 		<complexContent>
 			<extension base="iwxxm:SIGMETType">
 				<sequence>
-					<element name="tropicalCyclone" type="metce:TropicalCyclonePropertyType">
+					<element name="tropicalCyclone" type="metce:TropicalCyclonePropertyPropertyType">
 						<annotation>
 							<documentation>The tropical cyclone being reported in this SIGMET.
 
@@ -304,7 +304,7 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 		<complexContent>
 			<extension base="iwxxm:SIGMETType">
 				<sequence>
-					<element name="eruptingVolcano" type="metce:VolcanoPropertyType">
+					<element name="eruptingVolcano" type="metce:VolcanoPropertyPropertyType">
 						<annotation>
 							<documentation>The volcano that is erupting</documentation>
 						</annotation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -109,7 +109,6 @@ A6-1: "Location indicator of FIR/CTA"</documentation>
 						</annotation>
 					</element>
 				    <element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
-					<element name="flightInformationRegionBoundary" type="gml:GeometryPropertyType" minOccurs="0"/>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:om="http://www.opengis.net/om/2.0" xmlns:metce="http://def.wmo.int/metce/2013" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://def.wmo.int/metce/2013" schemaLocation="http://schemas.wmo.int/metce/1.2/metce.xsd"></import>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -21,6 +20,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:SIGMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
@@ -108,11 +108,14 @@ A6-1: "Location indicator of FIR/CTA"</documentation>
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
+				    <element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
+					<element name="flightInformationRegionBoundary" type="gml:GeometryPropertyType" minOccurs="0"/>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>
 						</annotation>
 					</element>
+				    <element name="issueTime" type="gml:TimeInstantPropertyType"/>
 					<element name="validPeriod" type="gml:TimePeriodPropertyType">
 						<annotation>
 							<documentation>The valid period for the entire report, including all observations and forecast conditions.  Each observation/forecast phenomenon includes its own period of validity for described meteorological conditions, which is represented as the O&amp;M Observation validTime.
@@ -141,14 +144,14 @@ YUDD SIGMET A3 VALID ...</documentation>
 The expected end of occurrence of volcanic ash ("NO VA EXP") is indicated with a missing SIGMET phenomenon with a nil reason of nothingOfOperationalSignificance</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:SIGMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>SIGMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  All combinations of observations and forecasts of meteorological conditions, including changing conditions, are represented by their own SIGMETEvolvingMeteorologicalCondition.
 
 Each analysis has a single EvolvingMeteorologicalCondition as its result.  </documentation>
 						</annotation>
 					</element>
-					<element name="forecastPositionAnalysis" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="forecastPositionAnalysis" type="iwxxm:SIGMETPositionCollectionPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>One or more forecast positions at the end of the valid period - one for each phenomenon area within an FIR.  These are modeled as a single OM_Observation sub-type with a feature collection result due to the shared time and other observation metadata for all forecast positions.</documentation>
 						</annotation>
@@ -320,6 +323,7 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:SIGMETPositionPropertyType" minOccurs="1" maxOccurs="2"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns:metce="http://def.wmo.int/metce/2013" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://def.wmo.int/metce/2013" schemaLocation="http://schemas.wmo.int/metce/1.2/metce.xsd"></import>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
@@ -20,9 +20,13 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:SIGMETEvolvingConditionPropertyType" minOccurs="1" maxOccurs="2"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which meteorological phenomena occur</documentation>
+						</annotation>
+					</element>
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMETEvolvingConditionCollection</documentation>
 						</annotation>
@@ -61,7 +65,7 @@ In cases where the position covers an entire FIR or CTA, ("ENTIRE CTA or ENTIRE 
 							<documentation>The geographic region affected by the reported phenomenon at a particular time (thunderstorms, volcanic ash, etc.).  This geometry covers all combinations of phenomenon historically reported in Annex 3: a boundary with a base and top, a TC centre position, and a VA line with a width</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMETPosition</documentation>
 						</annotation>
@@ -95,6 +99,11 @@ SIGMETs may report either observed or forecast hazardous conditions. Additionall
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
+					<element name="issueTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which this report was issued</documentation>
+						</annotation>
+					</element>
 					<element name="issuingAirTrafficServicesUnit" type="iwxxm:UnitPropertyType">
 						<annotation>
 							<documentation>The ATS unit serving the FIR or CTA to which the SIGMET refers
@@ -108,13 +117,16 @@ A6-1: "Location indicator of FIR/CTA"</documentation>
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
-				    <element name="flightInformationRegion" type="iwxxm:AirspacePropertyType"/>
+					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType">
+						<annotation>
+							<documentation>The ATS region (FIR, UIR, CTA, or FIR/UIR)</documentation>
+						</annotation>
+					</element>
 					<element name="sequenceNumber" type="string">
 						<annotation>
 							<documentation>The sequence number of this message.  For example: "5", "A3", or "2"</documentation>
 						</annotation>
 					</element>
-				    <element name="issueTime" type="gml:TimeInstantPropertyType"/>
 					<element name="validPeriod" type="gml:TimePeriodPropertyType">
 						<annotation>
 							<documentation>The valid period for the entire report, including all observations and forecast conditions.  Each observation/forecast phenomenon includes its own period of validity for described meteorological conditions, which is represented as the O&amp;M Observation validTime.
@@ -143,24 +155,52 @@ YUDD SIGMET A3 VALID ...</documentation>
 The expected end of occurrence of volcanic ash ("NO VA EXP") is indicated with a missing SIGMET phenomenon with a nil reason of nothingOfOperationalSignificance</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:SIGMETEvolvingConditionCollectionPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="analysis" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>SIGMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  All combinations of observations and forecasts of meteorological conditions, including changing conditions, are represented by their own SIGMETEvolvingMeteorologicalCondition.
 
 Each analysis has a single EvolvingMeteorologicalCondition as its result.  </documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:SIGMETEvolvingConditionCollection"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element SIGMET</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
-					<element name="forecastPositionAnalysis" type="iwxxm:SIGMETPositionCollectionPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="forecastPositionAnalysis" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>One or more forecast positions at the end of the valid period - one for each phenomenon area within an FIR.  These are modeled as a single OM_Observation sub-type with a feature collection result due to the shared time and other observation metadata for all forecast positions.</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:SIGMETPositionCollection"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element SIGMET</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
 					<element name="volcanicAshMovedToFIR" type="iwxxm:AirspacePropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The FIR to which volcanic ash has moved.  Reported only on SIGMET cancellation reports</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMET</documentation>
 						</annotation>
@@ -225,7 +265,7 @@ To report an airspace upper limit of above FL 300, airspace upper limit is repor
 speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]" (knots).</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMETEvolvingCondition</documentation>
 						</annotation>
@@ -267,7 +307,7 @@ speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]
 When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclone is unnamed</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneSIGMET</documentation>
 						</annotation>
@@ -297,7 +337,7 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 							<documentation>The volcano that is erupting</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshSIGMET</documentation>
 						</annotation>
@@ -322,9 +362,8 @@ When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclo
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType"/>
 					<element name="member" type="iwxxm:SIGMETPositionPropertyType" minOccurs="1" maxOccurs="2"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element SIGMETPositionCollection</documentation>
 						</annotation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -155,45 +155,17 @@ YUDD SIGMET A3 VALID ...</documentation>
 The expected end of occurrence of volcanic ash ("NO VA EXP") is indicated with a missing SIGMET phenomenon with a nil reason of nothingOfOperationalSignificance</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" minOccurs="0" maxOccurs="1">
+					<element name="analysis" type="iwxxm:SIGMETEvolvingConditionCollectionType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>SIGMETs may include the same phenomenon covering more than one area within the FIR/UIR/CTA, as well as observed and forecast conditions for each of these reported areas.  All combinations of observations and forecasts of meteorological conditions, including changing conditions, are represented by their own SIGMETEvolvingMeteorologicalCondition.
 
 Each analysis has a single EvolvingMeteorologicalCondition as its result.  </documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:SIGMETEvolvingConditionCollection"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element SIGMET</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
-					<element name="forecastPositionAnalysis" minOccurs="0" maxOccurs="1">
+					<element name="forecastPositionAnalysis" type="iwxxm:SIGMETPositionCollectionType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>One or more forecast positions at the end of the valid period - one for each phenomenon area within an FIR.  These are modeled as a single OM_Observation sub-type with a feature collection result due to the shared time and other observation metadata for all forecast positions.</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:SIGMETPositionCollection"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element SIGMET</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element name="volcanicAshMovedToFIR" type="iwxxm:AirspacePropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -41,12 +41,12 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The time frame at which this report is valid.  All forecast elements should be valid within this period</documentation>
 						</annotation>
 					</element>
-					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastType" minOccurs="0" maxOccurs="1">
+					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing conditions.  Mandatory in all cases except missing or cancelled reports</documentation>
 						</annotation>
 					</element>
-					<element name="changeForecast" type="iwxxm:MeteorologicalAerodromeForecastType" minOccurs="0" maxOccurs="unbounded">
+					<element name="changeForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Forecast that modifies the base forecast.  While there is no maximum number of forecasts, this should normally not exceed five in number. &lt;b&gt;&lt;u&gt; &lt;/u&gt;&lt;/b&gt;ICAO Annex 3 / WMO No. 49-2: Section 1.5: "The number of change and probability groups should be kept to a minimum and should not normally exceed five groups".</documentation>
 						</annotation>
@@ -121,7 +121,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 						</annotation>
 					</element>
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element name="weather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
+					<element name="weather" type="iwxxm:AerodromeForecastWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
 					<element name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="temperature" type="iwxxm:AerodromeAirTemperatureForecastPropertyType" minOccurs="0" maxOccurs="2"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -26,10 +26,14 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
-				    <element name="aerodrome" type="iwxxm:AirportHeliportPropertyType"/>
 					<element name="issueTime" type="gml:TimeInstantPropertyType">
 						<annotation>
 							<documentation>The time at which this report was issued.  Note that this should be identical to the resultTime of each MeteorologicalAerodromeForecast, whose results are made available at the same time as this report.  TAF reports have an issueTime to assist in discovery and to provide unambiguous semantics at the report level.</documentation>
+						</annotation>
+					</element>
+					<element name="aerodrome" type="iwxxm:AirportHeliportPropertyType">
+						<annotation>
+							<documentation>The aerodrome location for this report</documentation>
 						</annotation>
 					</element>
 					<element name="validTime" type="gml:TimePeriodPropertyType" minOccurs="0" maxOccurs="1">
@@ -37,15 +41,43 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The time frame at which this report is valid.  All forecast elements should be valid within this period</documentation>
 						</annotation>
 					</element>
-					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="1">
+					<element name="baseForecast" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing conditions.  Mandatory in all cases except missing or cancelled reports</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:MeteorologicalAerodromeForecast"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element TAF</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
-				    <element name="changeForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="changeForecast" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Forecast that modifies the base forecast.  While there is no maximum number of forecasts, this should normally not exceed five in number. &lt;b&gt;&lt;u&gt; &lt;/u&gt;&lt;/b&gt;ICAO Annex 3 / WMO No. 49-2: Section 1.5: "The number of change and probability groups should be kept to a minimum and should not normally exceed five groups".</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:MeteorologicalAerodromeForecast"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element TAF</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
 					<element name="previousReportAerodrome" type="iwxxm:AirportHeliportPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
@@ -57,7 +89,7 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The valid time period for the previously amended and/or cancelled report</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element TAF</documentation>
 						</annotation>
@@ -82,7 +114,7 @@ Missing reports indicate that a report was not issued from the responsible repor
 	</complexType>
 	<element name="MeteorologicalAerodromeForecast" type="iwxxm:MeteorologicalAerodromeForecastType" substitutionGroup="gml:AbstractGML">
 		<annotation>
-			<documentation>A specialized Record type containing meteorological conditions forecast at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeTrendForecast, which is reported on a METAR/SPECI - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
+			<documentation>Meteorological conditions forecast at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeTrendForecast, which is reported on a METAR/SPECI - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
 
 When no clouds of operational significance or no weather of operational significance is predicted, the nothingOfOperationalSignificance nilReason should be used for the cloud or presentWeather association.
 
@@ -97,7 +129,6 @@ Note that the TAC representations for "FM", "TL", and "AT" are represented by th
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility, mandatory except when ceiling and visibility is reported as OK
@@ -121,7 +152,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 					<element name="weather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="temperature" type="iwxxm:AerodromeAirTemperatureForecastPropertyType" minOccurs="0" maxOccurs="2"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeForecast</documentation>
 						</annotation>
@@ -198,7 +229,7 @@ ICAO Annex 3 / WMO No. 49-2:
 "TN"</documentation>
 				</annotation>
 			</element>
-			<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+			<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>Extension block for optional and/or additional parameters for element AerodromeAirTemperatureForecast</documentation>
 				</annotation>

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>TAF reporting constructs as defined in ICAO Annex 3 / WMO No. 49-2.
@@ -27,6 +26,7 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
+				    <element name="aerodrome" type="iwxxm:AirportHeliportPropertyType"/>
 					<element name="issueTime" type="gml:TimeInstantPropertyType">
 						<annotation>
 							<documentation>The time at which this report was issued.  Note that this should be identical to the resultTime of each MeteorologicalAerodromeForecast, whose results are made available at the same time as this report.  TAF reports have an issueTime to assist in discovery and to provide unambiguous semantics at the report level.</documentation>
@@ -37,12 +37,13 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The time frame at which this report is valid.  All forecast elements should be valid within this period</documentation>
 						</annotation>
 					</element>
-					<element name="baseForecast" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="1">
+				    <element name="forecastLocation" type="gml:PointPropertyType" minOccurs="0"/>
+					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing conditions.  Mandatory in all cases except missing or cancelled reports</documentation>
 						</annotation>
 					</element>
-					<element name="changeForecast" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="unbounded">
+				    <element name="changeForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Forecast that modifies the base forecast.  While there is no maximum number of forecasts, this should normally not exceed five in number. &lt;b&gt;&lt;u&gt; &lt;/u&gt;&lt;/b&gt;ICAO Annex 3 / WMO No. 49-2: Section 1.5: "The number of change and probability groups should be kept to a minimum and should not normally exceed five groups".</documentation>
 						</annotation>
@@ -80,9 +81,9 @@ Missing reports indicate that a report was not issued from the responsible repor
 		<attributeGroup ref="gml:AssociationAttributeGroup"></attributeGroup>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"></attributeGroup>
 	</complexType>
-	<element name="MeteorologicalAerodromeForecastRecord" type="iwxxm:MeteorologicalAerodromeForecastRecordType" substitutionGroup="gml:AbstractGML">
+	<element name="MeteorologicalAerodromeForecast" type="iwxxm:MeteorologicalAerodromeForecastType" substitutionGroup="gml:AbstractGML">
 		<annotation>
-			<documentation>A specialized Record type containing meteorological conditions forecast at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeTrendForecastRecord, which is reported on a METAR/SPECI - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
+			<documentation>A specialized Record type containing meteorological conditions forecast at an aerodrome.  This class is also related but not identical to MeteorologicalAerodromeTrendForecast, which is reported on a METAR/SPECI - conditions reported in trend forecasts in METAR/SPECI differ from forecast groups in a TAF.
 
 When no clouds of operational significance or no weather of operational significance is predicted, the nothingOfOperationalSignificance nilReason should be used for the cloud or presentWeather association.
 
@@ -93,10 +94,11 @@ Note that the TAC representations for "FM", "TL", and "AT" are represented by th
     AT - a phenomenonTime with a TimeInstant</documentation>
 		</annotation>
 	</element>
-	<complexType name="MeteorologicalAerodromeForecastRecordType">
+	<complexType name="MeteorologicalAerodromeForecastType">
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility, mandatory except when ceiling and visibility is reported as OK
@@ -122,7 +124,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 					<element name="temperature" type="iwxxm:AerodromeAirTemperatureForecastPropertyType" minOccurs="0" maxOccurs="2"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
-							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeForecastRecord</documentation>
+							<documentation>Extension block for optional and/or additional parameters for element MeteorologicalAerodromeForecast</documentation>
 						</annotation>
 					</element>
 				</sequence>
@@ -130,7 +132,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 					<annotation>
 						<documentation>The type of change being reported (FROM, BECOMING,  TEMPORARY, etc.).
 
-A change indicator is required for all MeteorologicalAerodromeForecastRecords excepting reported base conditions.</documentation>
+A change indicator is required for all MeteorologicalAerodromeForecasts excepting reported base conditions.</documentation>
 					</annotation>
 				</attribute>
 				<attribute use="required" name="cloudAndVisibilityOK" type="boolean">
@@ -143,9 +145,9 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 			</extension>
 		</complexContent>
 	</complexType>
-	<complexType name="MeteorologicalAerodromeForecastRecordPropertyType">
+	<complexType name="MeteorologicalAerodromeForecastPropertyType">
 		<sequence minOccurs="0">
-			<element ref="iwxxm:MeteorologicalAerodromeForecastRecord"></element>
+			<element ref="iwxxm:MeteorologicalAerodromeForecast"></element>
 		</sequence>
 		<attributeGroup ref="gml:AssociationAttributeGroup"></attributeGroup>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"></attributeGroup>

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -101,6 +101,11 @@ Note that the TAC representations for "FM", "TL", and "AT" are represented by th
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility, mandatory except when ceiling and visibility is reported as OK
@@ -121,7 +126,7 @@ When no operator is reported, prevailing visibility represents an exact value wi
 						</annotation>
 					</element>
 					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element name="weather" type="iwxxm:AerodromeForecastWeatherPropertyType" minOccurs="0" maxOccurs="3"></element>
+					<element name="weather" type="iwxxm:AerodromeForecastWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element name="cloud" type="iwxxm:AerodromeCloudForecastPropertyType" minOccurs="0" maxOccurs="1"></element>
 					<element name="temperature" type="iwxxm:AerodromeAirTemperatureForecastPropertyType" minOccurs="0" maxOccurs="2"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -41,43 +41,15 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The time frame at which this report is valid.  All forecast elements should be valid within this period</documentation>
 						</annotation>
 					</element>
-					<element name="baseForecast" minOccurs="0" maxOccurs="1">
+					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing conditions.  Mandatory in all cases except missing or cancelled reports</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:MeteorologicalAerodromeForecast"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element TAF</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
-					<element name="changeForecast" minOccurs="0" maxOccurs="unbounded">
+					<element name="changeForecast" type="iwxxm:MeteorologicalAerodromeForecastType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Forecast that modifies the base forecast.  While there is no maximum number of forecasts, this should normally not exceed five in number. &lt;b&gt;&lt;u&gt; &lt;/u&gt;&lt;/b&gt;ICAO Annex 3 / WMO No. 49-2: Section 1.5: "The number of change and probability groups should be kept to a minimum and should not normally exceed five groups".</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:MeteorologicalAerodromeForecast"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element TAF</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element name="previousReportAerodrome" type="iwxxm:AirportHeliportPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -37,7 +37,6 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 							<documentation>The time frame at which this report is valid.  All forecast elements should be valid within this period</documentation>
 						</annotation>
 					</element>
-				    <element name="forecastLocation" type="gml:PointPropertyType" minOccurs="0"/>
 					<element name="baseForecast" type="iwxxm:MeteorologicalAerodromeForecastPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing conditions.  Mandatory in all cases except missing or cancelled reports</documentation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
 		<documentation>Tropical Cyclone Advisory reporting constructs as defined in ICAO Annex 3 / WMO No. 49-2.
@@ -39,12 +38,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Advisory number, starting with 1 for each cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="om:OM_ObservationPropertyType">
+					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsPropertyType">
 						<annotation>
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="forecast" type="om:OM_ObservationPropertyType" minOccurs="4" maxOccurs="4">
+				    <element name="forecast" type="iwxxm:TropicalCycloneForecastConditionsPropertyType" minOccurs="4" maxOccurs="4">
 						<annotation>
 							<documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
 						</annotation>
@@ -86,6 +85,8 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
+				    <element name="tropicalCyclonePosition" type="gml:PointPropertyType"/>
 					<element name="movement" type="iwxxm:TropicalCycloneMovementType">
 						<annotation>
 							<documentation>The movement observed for the tropical cyclone</documentation>
@@ -136,6 +137,8 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
+				    <element name="tropicalCyclonePosition" type="gml:PointPropertyType"/>
 					<element name="maximumSurfaceWindSpeed" type="gml:SpeedType">
 						<annotation>
 							<documentation>The forecast maximum surface wind speed.  Maximum wind speeds shall be provided in either two units of measures: "m/s"or "[kn_i]" (knot).</documentation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -38,7 +38,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Advisory number, starting with 1 for each cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsType">
+					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsPropertyType">
 						<annotation>
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -43,25 +43,11 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="forecast" minOccurs="4" maxOccurs="4">
-						<annotation>
-							<documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
-						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:TropicalCycloneForecastConditions"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneAdvisory</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
-					</element>
+				    <element name="forecast" type="iwxxm:TropicalCycloneForecastConditionsPropertyType" minOccurs="4" maxOccurs="4">
+				        <annotation>
+				            <documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
+				        </annotation>
+				    </element>
 					<element name="remarks" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Remarks, as necessary</documentation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -38,15 +38,43 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Advisory number, starting with 1 for each cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsPropertyType">
+					<element name="observation">
 						<annotation>
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:TropicalCycloneObservedConditions"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneAdvisory</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
-				    <element name="forecast" type="iwxxm:TropicalCycloneForecastConditionsPropertyType" minOccurs="4" maxOccurs="4">
+					<element name="forecast" minOccurs="4" maxOccurs="4">
 						<annotation>
 							<documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:TropicalCycloneForecastConditions"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneAdvisory</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
 					<element name="remarks" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
@@ -60,7 +88,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 When no subsequent advisory is expected to be issued it should be indicated by a missing expected advisory time with a nil reason of 'inapplicable'</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneAdvisory</documentation>
 						</annotation>
@@ -85,8 +113,16 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
-				    <element name="tropicalCyclonePosition" type="gml:PointPropertyType"/>
+					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which meteorological phenomena occur</documentation>
+						</annotation>
+					</element>
+					<element name="tropicalCyclonePosition" type="gml:PointPropertyType">
+						<annotation>
+							<documentation>The tropical cyclone position</documentation>
+						</annotation>
+					</element>
 					<element name="movement" type="iwxxm:TropicalCycloneMovementType">
 						<annotation>
 							<documentation>The movement observed for the tropical cyclone</documentation>
@@ -112,7 +148,7 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 							<documentation>The mean maximum surface wind near the cyclone centre over 10 minutes.  Mean maximum wind speeds shall be provided in either two units of measures: "m/s" or "[kn_i]" (knot).</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneObservedConditions</documentation>
 						</annotation>
@@ -137,14 +173,22 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
-				    <element name="tropicalCyclonePosition" type="gml:PointPropertyType"/>
+					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which meteorological phenomena occur</documentation>
+						</annotation>
+					</element>
+					<element name="tropicalCyclonePosition" type="gml:PointPropertyType">
+						<annotation>
+							<documentation>The tropical cyclone position</documentation>
+						</annotation>
+					</element>
 					<element name="maximumSurfaceWindSpeed" type="gml:SpeedType">
 						<annotation>
 							<documentation>The forecast maximum surface wind speed.  Maximum wind speeds shall be provided in either two units of measures: "m/s"or "[kn_i]" (knot).</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneForecastConditions</documentation>
 						</annotation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -38,24 +38,10 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Advisory number, starting with 1 for each cyclone</documentation>
 						</annotation>
 					</element>
-					<element name="observation">
+					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsType">
 						<annotation>
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:TropicalCycloneObservedConditions"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneAdvisory</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element name="forecast" minOccurs="4" maxOccurs="4">
 						<annotation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -26,7 +26,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The issuing VAAC</documentation>
 						</annotation>
 					</element>
-					<element name="volcano" type="metce:EruptingVolcanoPropertyPropertyType">
+					<element name="volcano" type="metce:EruptingVolcanoPropertyType">
 						<annotation>
 							<documentation>The erupting volcano that is the source of volcanic ash</documentation>
 						</annotation>
@@ -41,7 +41,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Information source - described in free text</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="colourCode" type="iwxxm:AviationColourCodePropertyType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="colourCode" type="iwxxm:AviationColourCodeType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The aviation colour code</documentation>
 						</annotation>
@@ -91,7 +91,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="ashCloud" type="iwxxm:VolcanicAshCloudPropertyType" minOccurs="1" maxOccurs="unbounded"></element>
+				    <element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+				        <annotation>
+				            <documentation>The time at which meteorological phenomena occur</documentation>
+				        </annotation>
+				    </element>
+				    <element name="ashCloud" type="iwxxm:VolcanicAshCloudPropertyType" minOccurs="1" maxOccurs="unbounded"></element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshConditions</documentation>
@@ -117,11 +122,6 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
-						<annotation>
-							<documentation>The time at which meteorological phenomena occur</documentation>
-						</annotation>
-					</element>
 					<element nillable="true" name="ashCloudExtent" type="aixm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The horizontal and vertical extent of the ash cloud</documentation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -26,7 +26,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The issuing VAAC</documentation>
 						</annotation>
 					</element>
-					<element name="volcano" type="metce:EruptingVolcanoPropertyType">
+					<element name="volcano" type="metce:EruptingVolcanoPropertyPropertyType">
 						<annotation>
 							<documentation>The erupting volcano that is the source of volcanic ash</documentation>
 						</annotation>
@@ -41,12 +41,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>Information source - described in free text</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="colourCode" type="iwxxm:AviationColourCodeType" minOccurs="0" maxOccurs="1">
+					<element nillable="true" name="colourCode" type="iwxxm:AviationColourCodePropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The aviation colour code</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:VolcanicAshConditionsType" minOccurs="0" maxOccurs="unbounded">
+					<element name="analysis" type="iwxxm:VolcanicAshConditionsPropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The observed and estimated positions of volcanic ash clouds.  Each analysis represents an observed or 6/12/18 hour forecast of volcanic ash.</documentation>
 						</annotation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -46,24 +46,10 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The aviation colour code</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" minOccurs="0" maxOccurs="unbounded">
+					<element name="analysis" type="iwxxm:VolcanicAshConditionsType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The observed and estimated positions of volcanic ash clouds.  Each analysis represents an observed or 6/12/18 hour forecast of volcanic ash.</documentation>
 						</annotation>
-						<complexType>
-							<complexContent>
-								<extension base="gml:AbstractMemberType">
-									<sequence>
-										<element ref="iwxxm:VolcanicAshConditions"></element>
-										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-											<annotation>
-												<documentation>Extension block for optional and/or additional parameters for element VolcanicAshAdvisory</documentation>
-											</annotation>
-										</element>
-									</sequence>
-								</extension>
-							</complexContent>
-						</complexType>
 					</element>
 					<element name="remarks" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:metce="http://def.wmo.int/metce/2013" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:metce="http://def.wmo.int/metce/2013" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
 	<import namespace="http://def.wmo.int/metce/2013" schemaLocation="http://schemas.wmo.int/metce/1.2/metce.xsd"></import>
@@ -46,10 +46,24 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The aviation colour code</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:VolcanicAshConditionsPropertyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="analysis" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The observed and estimated positions of volcanic ash clouds.  Each analysis represents an observed or 6/12/18 hour forecast of volcanic ash.</documentation>
 						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence>
+										<element ref="iwxxm:VolcanicAshConditions"></element>
+										<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
+											<annotation>
+												<documentation>Extension block for optional and/or additional parameters for element VolcanicAshAdvisory</documentation>
+											</annotation>
+										</element>
+									</sequence>
+								</extension>
+							</complexContent>
+						</complexType>
 					</element>
 					<element name="remarks" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
@@ -66,7 +80,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The earliest time at which the next advisory will be issued</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshAdvisory</documentation>
 						</annotation>
@@ -91,9 +105,8 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="ashCloud" type="iwxxm:VolcanicAshCloudPropertyType" minOccurs="1" maxOccurs="unbounded"></element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshConditions</documentation>
 						</annotation>
@@ -118,6 +131,11 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+					<element name="phenomenonTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which meteorological phenomena occur</documentation>
+						</annotation>
+					</element>
 					<element nillable="true" name="ashCloudExtent" type="aixm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The horizontal and vertical extent of the ash cloud</documentation>
@@ -138,14 +156,14 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The wind speed.  Only reported when volcanic ash is not identifiable from satellite data.  If speed of motion of ash cloud is estimated from wind speed, unit of measure shall be given in "m/s" or "[kn_i]" (knot).</documentation>
 						</annotation>
 					</element>
-					<element name="windDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
-						<annotation>
-							<documentation>The wind direction.  Only reported when volcanic ash is not identifiable from satellite data, and not reported when winds are variable.  Direction of movement shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
-						</annotation>
-					</element>
 					<element name="windLowerLimit" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The lower limits of wind conditions.  Only reported when volcanic ash is not identifiable from satellite data.</documentation>
+						</annotation>
+					</element>
+					<element name="windDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>The wind direction.  Only reported when volcanic ash is not identifiable from satellite data, and not reported when winds are variable.  Direction of movement shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
 						</annotation>
 					</element>
 					<element name="windLowerLimitReference" type="aixm:CodeVerticalReferenceBaseType" minOccurs="0" maxOccurs="1">
@@ -163,7 +181,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The lower limit vertical reference of wind conditions.  Only reported when volcanic ash is not identifiable from satellite data.</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshCloud</documentation>
 						</annotation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -142,14 +142,14 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The wind speed.  Only reported when volcanic ash is not identifiable from satellite data.  If speed of motion of ash cloud is estimated from wind speed, unit of measure shall be given in "m/s" or "[kn_i]" (knot).</documentation>
 						</annotation>
 					</element>
-					<element name="windLowerLimit" type="gml:LengthType" minOccurs="0" maxOccurs="1">
-						<annotation>
-							<documentation>The lower limits of wind conditions.  Only reported when volcanic ash is not identifiable from satellite data.</documentation>
-						</annotation>
-					</element>
 					<element name="windDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The wind direction.  Only reported when volcanic ash is not identifiable from satellite data, and not reported when winds are variable.  Direction of movement shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
+						</annotation>
+					</element>
+					<element name="windLowerLimit" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>The lower limits of wind conditions.  Only reported when volcanic ash is not identifiable from satellite data.</documentation>
 						</annotation>
 					</element>
 					<element name="windLowerLimitReference" type="aixm:CodeVerticalReferenceBaseType" minOccurs="0" maxOccurs="1">

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:metce="http://def.wmo.int/metce/2013" xmlns:om="http://www.opengis.net/om/2.0" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0RC1" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0RC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:metce="http://def.wmo.int/metce/2013" xmlns:aixm="http://www.aixm.aero/schema/5.1.1" xmlns="http://www.w3.org/2001/XMLSchema">
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1_profiles/AIXM_WX/5.1.1a/AIXM_Features.xsd"></import>
-	<import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"></import>
 	<import namespace="http://def.wmo.int/metce/2013" schemaLocation="http://schemas.wmo.int/metce/1.2/metce.xsd"></import>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -47,7 +46,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The aviation colour code</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="om:OM_ObservationPropertyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="analysis" type="iwxxm:VolcanicAshConditionsPropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The observed and estimated positions of volcanic ash clouds.  Each analysis represents an observed or 6/12/18 hour forecast of volcanic ash.</documentation>
 						</annotation>
@@ -92,6 +91,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
+				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType"/>
 					<element name="ashCloud" type="iwxxm:VolcanicAshCloudPropertyType" minOccurs="1" maxOccurs="unbounded"></element>
 					<element name="extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>


### PR DESCRIPTION
An initial set of changes for fleshing out concepts and approaches for simplification, later commits will include more examples, the schemas, UML, and Schematron rules. Whether to pursue further simplification beyond this point (such as collapsing METAR RVR and other nested content) will be determined once O&M removal is finalized.  Related to issues #27 and #47

There are not any schema changes in this PR because schema changes would complicate comparison and discussion at this point, but I can put corresponding schema changes into the PR whenever we are ready.  I only modified a representative sample of each product type so we can see the changes reflected across each product (METAR but not SPECI, SIGMET but not AIRMET, etc.).  Note that these modified examples don't exactly match with the earlier set that metrics were generated for, this round is more exhaustive and thorough.  

Please pay special attention to element names/concepts (such as the names we use for various time elements) - once these are set they will be around for a long time.  

**Specific changes in this PR**:
 - removed O&M, sampling features, and sampling spatial namespaces, their schema locations, etc.
 - moved aerodromes/FIRs to the report level (instead of being buried under O&M)
 - moved the location to the top level of the report, when appropriate
 - om:result content types (such as MeteorologicalAerodromeObservationRecord) moved under observation/forecast/analysis element.
 - om:result content types no longer include "Record" in the name (MeteorologicalAerodromeObservationRecord is now MeteorologicalAerodromeObservation)
 - om:phenomenonTime moved from O&M onto some former "Record" types
 - added issueTimes to AIR/SIGMET (note that this is a separate issue, #47, but closely related to O&M removal)
 - om:resultTimes were effectively removed - in O&M these are was always shared, report-level constructs that were xlinked between O&M observations
 - om:validTimes were effectively removed - this is a report-level construct so they were unified to the report level
 - minor note: removed all schemaLocations other than IWXXM.  Not 100% sure if this will validate in practice but there were some unnecessary extra schemaLocations being used.  To be revisited once schema changes are complete

Here are some updated metrics on the differences as compared to the master version of these files:

file group | avg depth | # elem | # ns | # lines | bytes no whitespace | bytes w/whitespace | bytes GZIPed
------- | ------- | ------- | ------- | ------- | ------- | ------- | -------
*.xml | 5.46 | 119.60 | 7 | 231 | 9847 | 13542 | 2995
*.noOM.xml | 4.84 | 87.60 | 4 | 176 | 6818 | 9742 | 2230
*.noOM.xml rel to *.xml | 89% | 73% | 57% | 76% | 69% | 72% | 74%
