### PR TITLE
METAR/SPECI nillable observations

### DIFF
--- a/3.0.0RC1/measures.xsd
+++ b/3.0.0RC1/measures.xsd
@@ -42,4 +42,28 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 			</extension>
 		</simpleContent>
 	</complexType>
+	<element name="MeasureWithNilReason" type="iwxxm:MeasureWithNilReasonType">
+		<annotation>
+			<documentation>A nillable Measure quantity.  Unlike the base measure, references to this type may be nil and may include a nilReason</documentation>
+		</annotation>
+	</element>
+    <complexType name="MeasureWithNilReasonType">
+        <simpleContent>
+            <extension base="gml:MeasureType">
+                <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+	<element name="VelocityWithNilReason" type="iwxxm:VelocityWithNilReasonType">
+		<annotation>
+			<documentation>A nillable Velocity quantity.  Unlike the base Velocity measure, references to this type may be nil and may include a nilReason</documentation>
+		</annotation>
+	</element>
+    <complexType name="VelocityWithNilReasonType">
+        <simpleContent>
+            <extension base="gml:MeasureType">
+                <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+        </simpleContent>
+    </complexType>
 </schema>

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema elementFormDefault="qualified" targetNamespace="http://icao.int/iwxxm/3.0" version="3.0.0RC1" xmlns:iwxxm="http://icao.int/iwxxm/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.w3.org/2001/XMLSchema">
+	<include schemaLocation="measures.xsd"></include>
 	<include schemaLocation="common.xsd"></include>
 	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
 	<annotation>
@@ -37,7 +38,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The time at which phenomena were observed.  This may differ from the times reported for forecast conditions</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
+					<element nillable="true" name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>
@@ -218,7 +219,7 @@ When no clouds of operational significance or no weather of operational signific
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-					<element name="airTemperature" type="gml:MeasureType">
+					<element nillable="true" name="airTemperature" type="iwxxm:MeasureWithNilReasonType">
 						<annotation>
 							<documentation>The observed air temperature.  This is the temperature indicated by a thermometer exposed to the air in a place sheltered from direct solar radiation.
 
@@ -228,7 +229,7 @@ Measured air temperature shall be given in degrees Celsius ("Cel").</documentati
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="dewpointTemperature" type="gml:MeasureType">
+					<element nillable="true" name="dewpointTemperature" type="iwxxm:MeasureWithNilReasonType">
 						<annotation>
 							<documentation>The observed dew point temperature.  This is the temperature to which a given air parcel must be cooled at constant pressure and constant water vapor content in order for saturation to occur.
 
@@ -238,7 +239,7 @@ Measured dew-point temperature shall be given in degrees Celsius ("Cel").</docum
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="qnh" type="gml:MeasureType">
+					<element nillable="true" name="qnh" type="iwxxm:MeasureWithNilReasonType">
 						<annotation>
 							<documentation>The observed QNH altimeter setting.
 
@@ -250,9 +251,33 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 							</appinfo>
 						</annotation>
 					</element>
-					<element name="surfaceWind" type="iwxxm:AerodromeSurfaceWindPropertyType"></element>
-					<element name="visibility" type="iwxxm:AerodromeHorizontalVisibilityPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element name="rvr" type="iwxxm:AerodromeRunwayVisualRangePropertyType" minOccurs="0" maxOccurs="4"></element>
+					<element nillable="true" name="surfaceWind">
+						<complexType>
+							<complexContent>
+								<extension base="iwxxm:AerodromeSurfaceWindPropertyType">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element nillable="true" name="visibility" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<complexContent>
+								<extension base="iwxxm:AerodromeHorizontalVisibilityPropertyType">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element nillable="true" name="rvr" minOccurs="0" maxOccurs="4">
+						<complexType>
+							<complexContent>
+								<extension base="iwxxm:AerodromeRunwayVisualRangePropertyType">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
 					<element nillable="true" name="presentWeather" type="iwxxm:AerodromePresentWeatherType" minOccurs="0" maxOccurs="3"></element>
 					<element nillable="true" name="cloud" minOccurs="0" maxOccurs="1">
 						<complexType>
@@ -263,9 +288,25 @@ Measured altimeter setting shall be given in hectoPascals ("hPa").</documentatio
 							</complexContent>
 						</complexType>
 					</element>
-					<element name="recentWeather" type="iwxxm:AerodromeRecentWeatherType" minOccurs="0" maxOccurs="3"></element>
-					<element name="windShear" type="iwxxm:AerodromeWindShearPropertyType" minOccurs="0" maxOccurs="1"></element>
-					<element name="seaState" type="iwxxm:AerodromeSeaStatePropertyType" minOccurs="0" maxOccurs="1"></element>
+					<element nillable="true" name="recentWeather" type="iwxxm:AerodromeRecentWeatherType" minOccurs="0" maxOccurs="3"></element>
+					<element nillable="true" name="windShear" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<complexContent>
+								<extension base="iwxxm:AerodromeWindShearPropertyType">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element nillable="true" name="seaState" minOccurs="0" maxOccurs="1">
+						<complexType>
+							<complexContent>
+								<extension base="iwxxm:AerodromeSeaStatePropertyType">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
 					<element nillable="true" name="runwayState" minOccurs="0" maxOccurs="unbounded">
 						<complexType>
 							<complexContent>
@@ -305,12 +346,12 @@ When CAVOK conditions are observed, no other information on visibility, runway v
 	</element>
 	<complexType name="AerodromeRunwayStateType">
 		<sequence>
-			<element name="runway" type="iwxxm:RunwayDirectionPropertyType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="runway" type="iwxxm:RunwayDirectionPropertyType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The runway to which the conditions apply.  The runway may be missing in cases where all runways are closed due to snow</documentation>
 				</annotation>
 			</element>
-			<element name="depositType" type="iwxxm:RunwayDepositsType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="depositType" type="iwxxm:RunwayDepositsType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The type of runway deposit, such as damp conditions, wet snow, or ice.
 
@@ -318,7 +359,7 @@ WMO 306:
 Table 0919</documentation>
 				</annotation>
 			</element>
-			<element name="contamination" type="iwxxm:RunwayContaminationType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="contamination" type="iwxxm:RunwayContaminationType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Proportion of runway surface that is contaminated - usually expressed as a percentage of the total runway area.
 
@@ -348,7 +389,7 @@ See WMO No. 306 WMO Code table 1079.</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="estimatedSurfaceFrictionOrBrakingAction" type="iwxxm:RunwayFrictionCoefficientType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The estimated surface friction or braking action for the affected runway.  When braking conditions are not reported and/or the runway is not operational estimatedSurfaceFrictionOrBrakingAction will not be reported.
 
@@ -391,12 +432,12 @@ Section 4.8.1.5, Table A3-2 "State of the runway"</documentation>
 	</element>
 	<complexType name="AerodromeRunwayVisualRangeType">
 		<sequence>
-			<element name="runway" type="iwxxm:RunwayDirectionPropertyType">
+			<element nillable="true" name="runway" type="iwxxm:RunwayDirectionPropertyType">
 				<annotation>
 					<documentation>The runway to which reported runway visual range information applies</documentation>
 				</annotation>
 			</element>
-			<element name="meanRVR" type="gml:LengthType">
+			<element nillable="true" name="meanRVR" type="iwxxm:DistanceWithNilReasonType">
 				<annotation>
 					<documentation>The mean recent runway visual range value observed. This mean represents the 10 minute average for observed RVR except when the 10-minute period immediately preceding the observation includes a marked discontinuity in runway visual range values, only those values occurring after the discontinuity is used for obtaining mean values.
 
@@ -412,7 +453,7 @@ Section 4.3.6.6</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="meanRVROperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="meanRVROperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The reported relational operator for the mean RVR. When reported, this operator is reported in conjunction with mean RVR.
 
@@ -450,7 +491,7 @@ Section 4.3.6.6a</documentation>
 	</element>
 	<complexType name="AerodromeSeaStateType">
 		<sequence>
-			<element name="seaSurfaceTemperature" type="gml:MeasureType">
+			<element nillable="true" name="seaSurfaceTemperature" type="iwxxm:MeasureWithNilReasonType">
 				<annotation>
 					<documentation>The sea-surface temperature observed by aeronautical meteorological stations established on offshore structures in support of helicopter operations.
 
@@ -465,14 +506,14 @@ Section 4.8.1.5a</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="significantWaveHeight" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="significantWaveHeight" type="iwxxm:DistanceWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The significant wave height observed.
 
 Significant wave height shall be reported in meters ("m").</documentation>
 				</annotation>
 			</element>
-			<element name="seaState" type="iwxxm:SeaSurfaceStateType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="seaState" type="iwxxm:SeaSurfaceStateType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The state of the sea observed by aeronautical meteorological stations established on offshore structures in support of helicopter operations
 
@@ -503,7 +544,7 @@ Table 3700</documentation>
 	</element>
 	<complexType name="AerodromeWindShearType">
 		<sequence>
-			<element name="runway" type="iwxxm:RunwayDirectionPropertyType" minOccurs="0" maxOccurs="unbounded">
+			<element nillable="true" name="runway" type="iwxxm:RunwayDirectionPropertyType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
 					<documentation>The specific runway(s) affected by wind shear at this aerodrome. No specific runways are reported when all runways are affected by wind shear</documentation>
 				</annotation>
@@ -584,7 +625,7 @@ Wind direction shall be given in degrees from true North. Plane angle unit of me
 	</element>
 	<complexType name="AerodromeSurfaceWindType">
 		<sequence>
-			<element name="meanWindDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="meanWindDirection" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The observed average wind direction from which the wind is blowing over the past ten minutes.  Not reported when winds are variable.
 
@@ -594,7 +635,7 @@ Wind direction shall be given in degrees from true North. Plane angle unit of me
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="meanWindSpeed" type="gml:SpeedType">
+			<element nillable="true" name="meanWindSpeed" type="iwxxm:VelocityWithNilReasonType">
 				<annotation>
 					<documentation>The average observed wind speed over the past ten minutes
 
@@ -607,14 +648,14 @@ Wind speeds shall be provided in either two units of measures: "m/s" or "[kn_i]"
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="meanWindSpeedOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="meanWindSpeedOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Indication that the mean wind speed is above or below the reported value.  To report a wind speed of at least 49 meters per second, wind speed is reported as 49 meters per second and the operator is reported as "above".
 
 When no operator is reported, wind speed is an exact value with identical semantics to other measured quantities.</documentation>
 				</annotation>
 			</element>
-			<element name="windGustSpeed" type="gml:SpeedType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="windGustSpeed" type="iwxxm:VelocityWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The maximum wind speed observed over the past ten minutes
 
@@ -627,14 +668,14 @@ Wind gusts shall be provided in either two units of measures: "m/s" or "[kn_i]" 
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="windGustSpeedOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="windGustSpeedOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>Indication that the wind gust speed is above or below the reported value.  To report a wind gust speed of at least 49 meters per second, wind gust speed is reported as 49 meters per second and the operator is reported as "above".
 
 When no operator is reported, wind gust speed is an exact value with identical semantics to other measured quantities.</documentation>
 				</annotation>
 			</element>
-			<element name="extremeClockwiseWindDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="extremeClockwiseWindDirection" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The extreme clockwise direction from which the wind is blowing, inclusive.
 
@@ -645,7 +686,7 @@ Section 4.1.5.2b</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="extremeCounterClockwiseWindDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="extremeCounterClockwiseWindDirection" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The extreme counter-clockwise direction from which the wind is blowing, inclusive.
 
@@ -684,7 +725,7 @@ Measured prevailing and minimum horizontal visibility, if present, shall be repo
 	</element>
 	<complexType name="AerodromeHorizontalVisibilityType">
 		<sequence>
-			<element name="prevailingVisibility" type="gml:LengthType">
+			<element nillable="true" name="prevailingVisibility" type="iwxxm:DistanceWithNilReasonType">
 				<annotation>
 					<documentation>The reported prevailing horizontal visibility at the surface that is representative of the aerodrome.
 
@@ -704,7 +745,7 @@ Section 4.2.4.4b</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="prevailingVisibilityOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="prevailingVisibilityOperator" type="iwxxm:RelationalOperatorType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The reported relational operator for the prevailing horizontal visibility.  When reported, this operator is reported in conjunction with prevailing visibility.
 
@@ -713,7 +754,7 @@ To report a prevailing visibility of at least 10000 meters, prevailing visibilit
 When no operator is reported, prevailing visibility represents an exact value with identical semantics to other measured quantities</documentation>
 				</annotation>
 			</element>
-			<element name="minimumVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="minimumVisibility" type="iwxxm:DistanceWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The minimum observed visibility.
 
@@ -731,7 +772,7 @@ should be reported, with no indication of direction."</documentation>
 					</appinfo>
 				</annotation>
 			</element>
-			<element name="minimumVisibilityDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+			<element nillable="true" name="minimumVisibilityDirection" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 				<annotation>
 					<documentation>The direction of the minimum visibility relative to the reporting station.  This is optional in cases where minimum visibility is reported but the visibility is fluctuating rapidly.  Minimum visibility is reported in cardinal and inter-cardinal directions (N, NE, E, SE, S, SW, W, and NW)
 


### PR DESCRIPTION
Closes #23. All observed phenomena on METAR/SPECI should now be nillable and should allow for nilReasons to be provided.  Added new WithNilReason types: MeasureWithNilReason and VelocityWithNilReason.  