### PR TITLE
Clarified TAF phenomenonTime usage with BECMG, always TimePeriod

### DIFF
--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -101,11 +101,11 @@ Note that the TAC representations for "FM", "TL", and "AT" are represented by th
 		<complexContent>
 			<extension base="gml:AbstractGMLType">
 				<sequence>
-				    <element name="phenomenonTime" type="iwxxm:TimeObjectPropertyType">
-				        <annotation>
-				            <documentation>The time at which meteorological phenomena occur</documentation>
-				        </annotation>
-				    </element>
+					<element name="phenomenonTime" type="gml:TimePeriodPropertyType">
+						<annotation>
+							<documentation>The time at which the reported phenomena occur.  For change indicators of FROM, PROB 30/40, and TEMPO this is the period of time at which reported meteorological conditions occur.  For BECOMING conditions this represents the time over which conditions are changing.  This is roughly equivalent to how time information is reported in the TAC codes</documentation>
+						</annotation>
+					</element>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The prevailing horizontal visibility, mandatory except when ceiling and visibility is reported as OK

--- a/3.0.0RC1/taf.xsd
+++ b/3.0.0RC1/taf.xsd
@@ -103,7 +103,7 @@ Note that the TAC representations for "FM", "TL", and "AT" are represented by th
 				<sequence>
 					<element name="phenomenonTime" type="gml:TimePeriodPropertyType">
 						<annotation>
-							<documentation>The time at which the reported phenomena occur.  For change indicators of FROM, PROB 30/40, and TEMPO this is the period of time at which reported meteorological conditions occur.  For BECOMING conditions this represents the time over which conditions are changing.  This is roughly equivalent to how time information is reported in the TAC codes</documentation>
+							<documentation>The time at which the reported phenomena or change of phenomena occur.  For change indicators of FROM, PROB 30/40, and TEMPO this is the period of time at which reported meteorological conditions occur.  For BECOMING conditions this represents the time over which conditions are changing.  This is equivalent to how time information is reported in the TAC codes</documentation>
 						</annotation>
 					</element>
 					<element name="prevailingVisibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
Closes #13. Added further documentation on TAF phenomenonTime to clarify the meaning with timeIndicators of BECOMING. phenomenonTime is now always a gml:TimePeriod rather than a TimeInstant OR TimePeriod, as TAF should always have a TimePeriod for its phenomenonTime.

@blchoy Please review the updated documentation/wording to ensure that this is clear for both data producers and consumers