### PR TITLE
Many properties are now optional for failed translation cases

### DIFF
--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -67,12 +67,12 @@ The AIRMET report class represents the base AIRMET types that may be reported su
 							<documentation>The ATS unit serving the FIR or CTA to which the AIRMET refers.  ICAO Annex 3 / WMO No. 49-2: A6-1: "Location indicator of FIR/CTA"</documentation>
 						</annotation>
 					</element>
-					<element name="originatingMeteorologicalWatchOffice" type="iwxxm:UnitPropertyType">
+					<element name="originatingMeteorologicalWatchOffice" type="iwxxm:UnitPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
-					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType">
+					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The ATS region (FIR, UIR, CTA, or FIR/UIR)</documentation>
 						</annotation>
@@ -101,7 +101,7 @@ YUDD AIRMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous AIRMET that is cancelled by this AIRMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonType">
+					<element name="phenomenon" type="iwxxm:AeronauticalAreaWeatherPhenomenonType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.</documentation>
 						</annotation>

--- a/3.0.0RC1/examples/airmet-translation-failed.xml
+++ b/3.0.0RC1/examples/airmet-translation-failed.xml
@@ -43,34 +43,7 @@
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
-    <iwxxm:originatingMeteorologicalWatchOffice>
-        <aixm:Unit gml:id="uuid.8831a1d6-dff0-49c7-81d6-802055d5be01">
-            <aixm:timeSlice>
-                <aixm:UnitTimeSlice gml:id="uuid.5d46b0da-40c0-4d6f-a331-10c05693ac7c">
-                    <gml:validTime/>
-                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                    <aixm:name>YUDD MWO</aixm:name>
-                    <aixm:type>MWO</aixm:type>
-                    <aixm:designator>YUDD</aixm:designator>
-                </aixm:UnitTimeSlice>
-            </aixm:timeSlice>
-        </aixm:Unit>
-    </iwxxm:originatingMeteorologicalWatchOffice>
-
-    <iwxxm:issuingAirTrafficServicesRegion>
-        <aixm:Airspace gml:id="uuid.02abae65-6254-4682-9bf3-eb5638d3c80f">
-            <aixm:timeSlice>
-                <aixm:AirspaceTimeSlice gml:id="uuid.bba3b2e0-9bc9-4cf5-a3b8-55dc56cdd753">
-                    <gml:validTime/>
-                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                    <aixm:type>OTHER:FIR_UIR</aixm:type>
-                    <aixm:designator>YUDD</aixm:designator>
-                    <aixm:name>SHANLON FIR/UIR</aixm:name>
-                </aixm:AirspaceTimeSlice>
-            </aixm:timeSlice>
-        </aixm:Airspace>
-    </iwxxm:issuingAirTrafficServicesRegion>
-
+    
     <iwxxm:sequenceNumber>1</iwxxm:sequenceNumber>
 
     <iwxxm:validPeriod>
@@ -79,9 +52,5 @@
             <gml:endPosition>2014-05-15T18:00:00</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validPeriod>
-
-    <iwxxm:phenomenon nilReason="missing"/>
-
-    <iwxxm:analysis nilReason="missing"/>
 
 </iwxxm:AIRMET>

--- a/3.0.0RC1/examples/metar-translation-failed.xml
+++ b/3.0.0RC1/examples/metar-translation-failed.xml
@@ -48,6 +48,4 @@
         </gml:TimeInstant>
     </iwxxm:observationTime>
     
-    <iwxxm:observation nilReason="missing"/>
-
 </iwxxm:METAR>

--- a/3.0.0RC1/examples/sigmet-A6-2-TC.xml
+++ b/3.0.0RC1/examples/sigmet-A6-2-TC.xml
@@ -33,6 +33,7 @@
             </aixm:timeSlice>
         </aixm:Unit>
     </iwxxm:issuingAirTrafficServicesUnit>
+
     <iwxxm:originatingMeteorologicalWatchOffice>
         <aixm:Unit gml:id="uuid.d8835dc7-18db-424e-929a-e4c79be92cad">
             <aixm:timeSlice>

--- a/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
+++ b/3.0.0RC1/examples/sigmet-translation-failed-collect.xml
@@ -50,33 +50,6 @@
                 </aixm:timeSlice>
               </aixm:Unit>
             </iwxxm:issuingAirTrafficServicesUnit>
-            <iwxxm:originatingMeteorologicalWatchOffice>
-              <aixm:Unit gml:id="uuid.701a3f46-6b7b-4878-ad74-71436d8c953c">
-                <aixm:timeSlice>
-                  <aixm:UnitTimeSlice gml:id="uuid.f99e1e20-003e-4605-bcfe-c1524a4cd7c2">
-                    <gml:validTime/>
-                    <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                    <aixm:name>YUSO MWO</aixm:name>
-                    <aixm:type>MWO</aixm:type>
-                    <aixm:designator>YUSO</aixm:designator>
-                  </aixm:UnitTimeSlice>
-                </aixm:timeSlice>
-              </aixm:Unit>
-            </iwxxm:originatingMeteorologicalWatchOffice>
-            
-            <iwxxm:issuingAirTrafficServicesRegion>
-                <aixm:Airspace gml:id="uuid.eb9d349c-242c-4193-981a-935ee2e547a2">
-                    <aixm:timeSlice>
-                        <aixm:AirspaceTimeSlice gml:id="uuid.23909d58-4be9-43a1-8eb8-2d1e3b64432e">
-                            <gml:validTime/>
-                            <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-                            <aixm:type>FIR</aixm:type>
-                            <aixm:designator>YUDD</aixm:designator>
-                            <aixm:name>SHANLON FIR</aixm:name>
-                        </aixm:AirspaceTimeSlice>
-                    </aixm:timeSlice>
-                </aixm:Airspace>
-            </iwxxm:issuingAirTrafficServicesRegion>
             
             <iwxxm:sequenceNumber>2</iwxxm:sequenceNumber>
             
@@ -86,10 +59,6 @@
                     <gml:endPosition>2012-08-10T16:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
             </iwxxm:validPeriod>
-        
-            <iwxxm:phenomenon nilReason="missing"/>
-        
-            <iwxxm:analysis nilReason="missing"/>
         
         </iwxxm:SIGMET>
 

--- a/3.0.0RC1/examples/taf-translation-failed.xml
+++ b/3.0.0RC1/examples/taf-translation-failed.xml
@@ -48,6 +48,5 @@
             <gml:endPosition>2012-08-16T18:00:00Z</gml:endPosition>
         </gml:TimePeriod>
     </iwxxm:validTime>
-    <iwxxm:baseForecast nilReason="missing"/>
 
 </iwxxm:TAF>

--- a/3.0.0RC1/examples/tc-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/tc-advisory-translation-failed.xml
@@ -45,14 +45,4 @@ INVALID INVALID INVALID
         </aixm:Unit>
     </iwxxm:issuingTropicalCycloneAdvisoryCentre>
 
-    <iwxxm:tropicalCycloneName>GLORIA</iwxxm:tropicalCycloneName>
-    <iwxxm:advisoryNumber>0</iwxxm:advisoryNumber>
-
-    <iwxxm:observation nilReason="missing"/>
-    <iwxxm:forecast nilReason="missing"/>
-    <iwxxm:forecast nilReason="missing"/>
-    <iwxxm:forecast nilReason="missing"/>
-    <iwxxm:forecast nilReason="missing"/>
-    <iwxxm:expectedNextAdvisoryTime/>
-
 </iwxxm:TropicalCycloneAdvisory>

--- a/3.0.0RC1/examples/va-advisory-translation-failed.xml
+++ b/3.0.0RC1/examples/va-advisory-translation-failed.xml
@@ -50,22 +50,4 @@ INVALID INVALID INVALID">
       </aixm:Unit>
     </iwxxm:issuingVolcanicAshAdvisoryCentre>
 
-    <iwxxm:volcano>
-        <metce:EruptingVolcano gml:id="uuid.a0853f49-b98d-41cd-87be-a3ffa6ffd352">
-            <gml:description>FL300 REPORTED</gml:description>
-            <metce:name>KARYMSKY 1000-13</metce:name>
-            <metce:position>
-                <gml:Point gml:id="uuid.4a863495-6f14-4921-9aa8-0162764772ed" srsName="http://www.opengis.net/def/crs/EPSG/0/4979">
-                    <gml:pos>54.03 159.27 1536</gml:pos>
-                </gml:Point>
-            </metce:position>
-            <metce:eruptionDate>2008-09-23T01:30:00Z</metce:eruptionDate>
-        </metce:EruptingVolcano>
-    </iwxxm:volcano>
-
-    <iwxxm:advisoryNumber></iwxxm:advisoryNumber>
-    <iwxxm:informationSource></iwxxm:informationSource>
-    <iwxxm:colourCode nilReason="missing"/>
-    <iwxxm:analysis nilReason="missing"/>
-
 </iwxxm:VolcanicAshAdvisory>

--- a/3.0.0RC1/metarSpeci.xsd
+++ b/3.0.0RC1/metarSpeci.xsd
@@ -65,7 +65,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The time at which phenomena were observed.  This may differ from the times reported for forecast conditions</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType">
+					<element nillable="true" name="observation" type="iwxxm:MeteorologicalAerodromeObservationPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The observation which resulted in the current meteorological conditions at an aerodrome</documentation>
 						</annotation>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -112,12 +112,12 @@ ICAO Annex 3 / WMO No. 49-2:
 A6-1: "Location indicator of FIR/CTA"</documentation>
 						</annotation>
 					</element>
-					<element name="originatingMeteorologicalWatchOffice" type="iwxxm:UnitPropertyType">
+					<element name="originatingMeteorologicalWatchOffice" type="iwxxm:UnitPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>MWO originating this report</documentation>
 						</annotation>
 					</element>
-					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType">
+					<element name="issuingAirTrafficServicesRegion" type="iwxxm:AirspacePropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The ATS region (FIR, UIR, CTA, or FIR/UIR)</documentation>
 						</annotation>
@@ -148,7 +148,7 @@ YUDD SIGMET A3 VALID ...</documentation>
 							<documentation>The valid period of a previous SIGMET that is cancelled by this SIGMET.  Mandatory when this is a cancellation report, must be missing otherwise</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonType">
+					<element nillable="true" name="phenomenon" type="iwxxm:AeronauticalSignificantWeatherPhenomenonType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The reported phenomenon, such as thunderstorm, tropical cyclone, icing, mountain wave, etc.
 
@@ -277,11 +277,6 @@ speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]
 							<documentation>The tropical cyclone being reported in this SIGMET, required in all cases other than cancellations. When reporting the tropical cyclone name, 'NN' may be used if the tropical cyclone is unnamed</documentation>
 						</annotation>
 					</element>
-					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-						<annotation>
-							<documentation>Extension block for optional and/or additional parameters for element TropicalCycloneSIGMET</documentation>
-						</annotation>
-					</element>
 				</sequence>
 			</extension>
 		</complexContent>
@@ -305,11 +300,6 @@ speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]
 					<element name="eruptingVolcano" type="metce:VolcanoPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The volcano that is erupting - required in all cases other than cancellations</documentation>
-						</annotation>
-					</element>
-					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">
-						<annotation>
-							<documentation>Extension block for optional and/or additional parameters for element VolcanicAshSIGMET</documentation>
 						</annotation>
 					</element>
 				</sequence>

--- a/3.0.0RC1/spaceWxAdvisory.xsd
+++ b/3.0.0RC1/spaceWxAdvisory.xsd
@@ -29,7 +29,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The issuing space weather centre (SWXC)</documentation>
 						</annotation>
 					</element>
-					<element name="advisoryNumber" type="string">
+					<element name="advisoryNumber" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Advisory number: four digit year and unique message number.  Example "2018/1"</documentation>
 						</annotation>
@@ -39,12 +39,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The number of the advisory being replaced.  Example "2018/1"</documentation>
 						</annotation>
 					</element>
-					<element name="phenomenon" type="iwxxm:SpaceWeatherPhenomenaType" minOccurs="1" maxOccurs="unbounded">
+					<element name="phenomenon" type="iwxxm:SpaceWeatherPhenomenaType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>The space weather phenomenon, such as radiation or satellite communication</documentation>
 						</annotation>
 					</element>
-					<element name="analysis" type="iwxxm:SpaceWeatherAnalysisPropertyType" minOccurs="1" maxOccurs="5">
+					<element name="analysis" type="iwxxm:SpaceWeatherAnalysisPropertyType" minOccurs="0" maxOccurs="5">
 						<annotation>
 							<documentation>Observed and forecast space weather information.  Analyses should be reported in the order in which they occur, starting with the initial observed/forecast conditions and proceeding through each subsequent forecast to the end of the period</documentation>
 						</annotation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -29,32 +29,32 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 							<documentation>The issuing TCAC</documentation>
 						</annotation>
 					</element>
-					<element name="tropicalCycloneName" type="string">
+					<element name="tropicalCycloneName" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The tropical cyclone name.  If the tropical cyclone is unnamed, 'NN' may be used</documentation>
 						</annotation>
 					</element>
-					<element name="advisoryNumber" type="string">
+					<element name="advisoryNumber" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Advisory number: year in full and message number (separate sequence for each cyclone)</documentation>
 						</annotation>
 					</element>
-					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsPropertyType">
+					<element name="observation" type="iwxxm:TropicalCycloneObservedConditionsPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The observed conditions of the tropical cyclone</documentation>
 						</annotation>
 					</element>
-				    <element name="forecast" type="iwxxm:TropicalCycloneForecastConditionsPropertyType" minOccurs="4" maxOccurs="4">
-				        <annotation>
-				            <documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
-				        </annotation>
-				    </element>
+					<element nillable="true" name="forecast" type="iwxxm:TropicalCycloneForecastConditionsPropertyType" minOccurs="0" maxOccurs="4">
+						<annotation>
+							<documentation>The forecast conditions of the tropical cyclone, one each for the 6 hour, 12 hour, 18 hour, and 24 hour forecast periods</documentation>
+						</annotation>
+					</element>
 					<element name="remarks" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Remarks, as necessary</documentation>
 						</annotation>
 					</element>
-					<element nillable="true" name="expectedNextAdvisoryTime" type="gml:TimeInstantPropertyType">
+					<element nillable="true" name="expectedNextAdvisoryTime" type="gml:TimeInstantPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The time at which the next advisory is expected to be issued.
 

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -20,23 +20,27 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="iwxxm:ReportType">
 				<sequence>
-					<element name="issueTime" type="gml:TimeInstantPropertyType"></element>
+					<element name="issueTime" type="gml:TimeInstantPropertyType">
+						<annotation>
+							<documentation>The time at which this report was issued</documentation>
+						</annotation>
+					</element>
 					<element name="issuingVolcanicAshAdvisoryCentre" type="iwxxm:UnitPropertyType">
 						<annotation>
 							<documentation>The issuing VAAC</documentation>
 						</annotation>
 					</element>
-					<element name="volcano" type="metce:EruptingVolcanoPropertyType">
+					<element name="volcano" type="metce:EruptingVolcanoPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>The erupting volcano that is the source of volcanic ash</documentation>
 						</annotation>
 					</element>
-					<element name="advisoryNumber" type="string">
+					<element name="advisoryNumber" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Advisory number: year in full and message number (separate sequence for each volcano)</documentation>
 						</annotation>
 					</element>
-					<element name="informationSource" type="string">
+					<element name="informationSource" type="string" minOccurs="0" maxOccurs="1">
 						<annotation>
 							<documentation>Information source - described in free text</documentation>
 						</annotation>
@@ -58,12 +62,12 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 					</element>
 					<element name="nextAdvisoryEarliestTime" type="gml:TimeInstantPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>The latest time at which the next advisory will be issued</documentation>
+							<documentation>The earliest time at which the next advisory will be issued</documentation>
 						</annotation>
 					</element>
 					<element name="nextAdvisoryLatestTime" type="gml:TimeInstantPropertyType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>The earliest time at which the next advisory will be issued</documentation>
+							<documentation>The latest time at which the next advisory will be issued</documentation>
 						</annotation>
 					</element>
 					<element name="extension" type="iwxxm:ExtensionType" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
Closes #41. Properties from most of the products have been made optional to support failed translation scenarios.  Schematron rules were implemented in the UML model to ensure these are present in all "normal" cases, but these need to be generated and checked by Choy and are not included in this commit.  Also removed VA SIGMET and TC SIGMET extension blocks to resolve "unique participle" failures in Oxygen - this was introduced with a recent checkin that made VA/TC SIGMET eruptingVolcano and tropicalCyclone elements optional. Minor documentation updates on VAA elements