### PR TITLE
Cease usage of aixm:AirspaceVolumePropertyType

### DIFF
--- a/3.0.0RC1/airmet.xsd
+++ b/3.0.0RC1/airmet.xsd
@@ -148,7 +148,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 							<documentation>The expected direction of movement of a meteorological condition. When no movement is expected, this is a http://www.opengis.net/def/nil/OGC/0/inapplicable nilReason and the speedOfMotion will be 0.  Direction of motion to shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
 						</annotation>
 					</element>
-					<element name="geometry" type="aixm:AirspaceVolumePropertyType">
+					<element name="geometry" type="iwxxm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The expected geographic region(s) affected by the reported phenomenon at a particular time (thunderstorms, volcanic ash, etc.).  This geometry covers all combinations of phenomenon historically reported in ICAO Annex 3 / WMO No. 49-2: a boundary with a base and top, a TC centre position, and a VA line with a width</documentation>
 						</annotation>

--- a/3.0.0RC1/common.xsd
+++ b/3.0.0RC1/common.xsd
@@ -331,6 +331,13 @@ For example, the "above" operator in conjunction with the reported quantity 10.6
 		<attributeGroup ref="gml:AssociationAttributeGroup"/>
 		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
 	</complexType>
+	<complexType name="AirspaceVolumePropertyType">
+		<sequence minOccurs="0">
+			<element ref="aixm:AirspaceVolume"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
 	<complexType name="AirportHeliportPropertyType">
 		<sequence minOccurs="0">
 			<element ref="aixm:AirportHeliport"/>

--- a/3.0.0RC1/sigmet.xsd
+++ b/3.0.0RC1/sigmet.xsd
@@ -60,7 +60,7 @@ In cases where the position covers an entire FIR or CTA, ("ENTIRE CTA or ENTIRE 
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="geometry" type="aixm:AirspaceVolumePropertyType">
+					<element name="geometry" type="iwxxm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The geographic region affected by the reported phenomenon at a particular time (thunderstorms, volcanic ash, etc.).  This geometry covers all combinations of phenomenon historically reported in Annex 3: a boundary with a base and top, a TC centre position, and a VA line with a width</documentation>
 						</annotation>
@@ -211,7 +211,7 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 This element value is given in degrees from true North. Plane angle unit of measure (uom) is "deg". </documentation>
 						</annotation>
 					</element>
-					<element name="geometry" type="aixm:AirspaceVolumePropertyType">
+					<element name="geometry" type="iwxxm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The expected geographic region(s) affected by the reported phenomenon at a particular time (thunderstorms, volcanic ash, etc.).  This geometry covers all combinations of phenomenon historically reported in ICAO Annex 3 / WMO No. 49-2: a boundary with a base and top, a TC centre position, and a VA line with a width</documentation>
 						</annotation>

--- a/3.0.0RC1/spaceWxAdvisory.xsd
+++ b/3.0.0RC1/spaceWxAdvisory.xsd
@@ -143,7 +143,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element name="location" type="aixm:AirspaceVolumePropertyType">
+					<element name="location" type="iwxxm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The geographic location at which space weather phenomena occur</documentation>
 						</annotation>

--- a/3.0.0RC1/tropicalCycloneAdvisory.xsd
+++ b/3.0.0RC1/tropicalCycloneAdvisory.xsd
@@ -96,7 +96,7 @@ When no subsequent advisory is expected to be issued it should be indicated by a
 							<documentation>The tropical cyclone position</documentation>
 						</annotation>
 					</element>
-					<element name="cumulonimbusCloudLocation" type="aixm:AirspaceVolumePropertyType" minOccurs="0" maxOccurs="unbounded">
+					<element name="cumulonimbusCloudLocation" type="iwxxm:AirspaceVolumePropertyType" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
 							<documentation>Location of cumulonimbus cloud</documentation>
 						</annotation>

--- a/3.0.0RC1/volcanicAshAdvisory.xsd
+++ b/3.0.0RC1/volcanicAshAdvisory.xsd
@@ -126,7 +126,7 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 		<complexContent>
 			<extension base="gml:AbstractFeatureType">
 				<sequence>
-					<element nillable="true" name="ashCloudExtent" type="aixm:AirspaceVolumePropertyType">
+					<element nillable="true" name="ashCloudExtent" type="iwxxm:AirspaceVolumePropertyType">
 						<annotation>
 							<documentation>The horizontal and vertical extent of the ash cloud</documentation>
 						</annotation>


### PR DESCRIPTION
Closes #94.  All usages of aixm:AirspaceVolumePropertyType have been replaced with iwxxm:AirspaceVolumePropertyType to allow for HTTP nilReasons to be reported.  This required a new AirspaceVolumePropertyType in common.xsd