### PR TITLE
Remove attribute isNilReason in METAR/SPECI and TAF

### DIFF
--- a/3.0.0RC2/TAC-to-XML-Guidance.txt
+++ b/3.0.0RC2/TAC-to-XML-Guidance.txt
@@ -12,7 +12,7 @@ The attribute "reportStatus" of a report shall be set to either "NORMAL", "AMEND
 METAR/SPECI
 ==========================
 NIL report
-  A NIL report shall be represented by setting attribute "isNilReport" true and making iwxxm:observation empty with a nilReason of "http://codes.wmo.int/common/nil/missing" 
+  A NIL report shall be represented by making iwxxm:observation empty with a nilReason of "http://codes.wmo.int/common/nil/missing" 
 
 CAVOK - Cloud and visibility OK
   When CAVOK conditions apply, the appropriate Record type shall have "cloudAndVisibilityOK" set to true and visibility, runway visual range, weather, and cloud information shall be absent
@@ -86,7 +86,7 @@ the wind which should be dxdxdx in the TAC report.  Similarly the corresponding 
 TAF
 ==========================
 NIL report
-  A NIL report shall be represented by setting attribute "isNilReport" true and making iwxxm:baseForecast empty with a nilReason of "http://codes.wmo.int/common/nil/missing" 
+  A NIL report shall be represented by making iwxxm:baseForecast empty with a nilReason of "http://codes.wmo.int/common/nil/missing" 
 
 CNL report
   A cancellation report shall be represented by setting attribute "isCancelReport" true, setting iwxxm:cancelledReportValidPeriod and making iwxxm:validPeriod, iwxxm:baseForecast and iwxxm:changeForecast empty. 

--- a/3.0.0RC2/examples/metar-NIL-collect.xml
+++ b/3.0.0RC2/examples/metar-NIL-collect.xml
@@ -21,7 +21,6 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC2/iwxxm.xsd"
             gml:id="uuid.15ff064a-6dc4-41e0-bafa-8ee78ed4dc25"
-            isNilReport="true"
             reportStatus="NORMAL"
             permissibleUsage="OPERATIONAL"
             automatedStation="false">
@@ -56,7 +55,7 @@
             </iwxxm:observationTime>
             
             <!-- NIL/missing reports do not have reported weather conditions -->
-	        <iwxxm:observation nilReason="http://codes.wmo.int/common/nil/missing"/>
+            <iwxxm:observation nilReason="http://codes.wmo.int/common/nil/missing"/>
 
         </iwxxm:METAR>
 

--- a/3.0.0RC2/examples/taf-NIL-collect.xml
+++ b/3.0.0RC2/examples/taf-NIL-collect.xml
@@ -21,8 +21,7 @@
             xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0.0RC2/iwxxm.xsd"
             gml:id="uuid.ae3b123f-4fa1-447e-aa0e-5a950c8abff2"
             reportStatus="NORMAL"
-            permissibleUsage="OPERATIONAL"
-            isNilReport="true">
+            permissibleUsage="OPERATIONAL">
 
             <iwxxm:issueTime>
                 <gml:TimeInstant gml:id="uuid.b28ba3dd-6544-4d7b-9a1f-342c63b458b5">
@@ -44,7 +43,7 @@
                 </aixm:AirportHeliport>
             </iwxxm:aerodrome>
         
- 	        <iwxxm:baseForecast nilReason="http://codes.wmo.int/common/nil/missing"/>
+            <iwxxm:baseForecast nilReason="http://codes.wmo.int/common/nil/missing"/>
 
         </iwxxm:TAF>
 

--- a/3.0.0RC2/metarSpeci.xsd
+++ b/3.0.0RC2/metarSpeci.xsd
@@ -49,11 +49,6 @@ References to WMO and ICAO Technical Regulations within this XML schema shall ha
 						</annotation>
 					</element>
 				</sequence>
-				<attribute name="isNilReport" type="boolean">
-					<annotation>
-						<documentation>Indicates whether the report is a 'Nil' report (true) or not (false or empty).</documentation>
-					</annotation>
-				</attribute>
 				<attribute name="automatedStation" type="boolean">
 					<annotation>
 						<documentation>When true, this report was reported by an automated station.</documentation>

--- a/3.0.0RC2/rule/iwxxm.sch
+++ b/3.0.0RC2/rule/iwxxm.sch
@@ -67,7 +67,7 @@
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MeteorologicalAerodromeObservationReport-3">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
-         <sch:assert test="( if( @isNilReport = 'true' and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:observationTime) and (empty(iwxxm:observation/*) and iwxxm:observation/@nilReason = 'http://codes.wmo.int/common/nil/missing') and empty(iwxxm:trendForecast) ) else( true() ) )">METAR_SPECI.MeteorologicalAerodromeObservationReport-3: A 'Nil' report should have appropriately filled elements including Iwxxm:issueTime, iwxxm:aerodrome, iwxxm:observationTime, iwxxm:observation (empty with nilReason) and iwxxm:trendForecast (missing)</sch:assert>
+         <sch:assert test="( if( (empty(iwxxm:observation/*) and iwxxm:observation/@nilReason = 'http://codes.wmo.int/common/nil/missing') and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:observationTime) and empty(iwxxm:trendForecast) ) else( true() ) )">METAR_SPECI.MeteorologicalAerodromeObservationReport-3: A 'Nil' report should have appropriately filled elements including Iwxxm:issueTime, iwxxm:aerodrome, iwxxm:observationTime, iwxxm:observation (empty with nilReason) and iwxxm:trendForecast (missing)</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MeteorologicalAerodromeObservationReport-2">
@@ -77,7 +77,7 @@
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.MeteorologicalAerodromeObservationReport-4">
       <sch:rule context="//iwxxm:METAR|//iwxxm:SPECI">
-         <sch:assert test="( if( (empty(@isNilReport) or @isNilReport = 'false' ) and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:observationTime) and (exists(iwxxm:observation) and empty(iwxxm:observation/@nilReason)) ) else( true() ) )">METAR_SPECI.MeteorologicalAerodromeObservationReport-4: An ordinary report should have appropriately filled elements including Iwxxm:issueTime, iwxxm:aerodrome, iwxxm:observationTime and iwxxm:observation</sch:assert>
+         <sch:assert test="( if( string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:observationTime) and exists(iwxxm:observation) ) else( true() ) )">METAR_SPECI.MeteorologicalAerodromeObservationReport-4: An ordinary report should have appropriately filled elements including Iwxxm:issueTime, iwxxm:aerodrome, iwxxm:observationTime and iwxxm:observation</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="METAR_SPECI.AerodromeSeaCondition.seaState">
@@ -277,7 +277,7 @@
    </sch:pattern>
    <sch:pattern id="TAF.TAF-3">
       <sch:rule context="//iwxxm:TAF">
-         <sch:assert test="( if( @isNilReport = 'true' and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and empty(iwxxm:validPeriod) and empty(iwxxm:cancelledReportValidPeriod) and (empty(iwxxm:baseForecast/*) and iwxxm:baseForecast/@nilReason = 'http://codes.wmo.int/common/nil/missing') and empty(iwxxm:changeForecast) ) else( true() ) )">TAF.TAF-3: A 'Nil' report should have appropriately filled elements including iwxxm:issueTime, iwxxm:aerodrome, iwxxm:validPeriod (missing), iwxxm:cancelledReportValidPeriod (missing), iwxxm:baseForecast (empty with nilReason) and iwxxm:changeForecast (missing)</sch:assert>
+         <sch:assert test="( if( (empty(iwxxm:baseForecast/*) and iwxxm:baseForecast/@nilReason = 'http://codes.wmo.int/common/nil/missing') and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and empty(iwxxm:validPeriod) and empty(iwxxm:cancelledReportValidPeriod) and empty(iwxxm:changeForecast) ) else( true() ) )">TAF.TAF-3: A 'Nil' report should have appropriately filled elements including iwxxm:issueTime, iwxxm:aerodrome, iwxxm:validPeriod (missing), iwxxm:cancelledReportValidPeriod (missing), iwxxm:baseForecast (empty with nilReason) and iwxxm:changeForecast (missing)</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.TAF-2">
@@ -287,7 +287,7 @@
    </sch:pattern>
    <sch:pattern id="TAF.TAF-5">
       <sch:rule context="//iwxxm:TAF">
-         <sch:assert test="(if( ((empty(@isNilReport) or @isNilReport = 'false') and (empty(@isCancelReport) or @isCancelReport = 'false')) and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:validPeriod) and empty(iwxxm:cancelledReportValidPeriod) and (exists(iwxxm:baseForecast) and empty(iwxxm:baseForecast/@nilReason)) ) else( true() ) )">TAF.TAF-5: An ordinary report should have appropriately filled elements including iwxxm:issueTime, iwxxm:aerodrome, iwxxm:validPeriod, iwxxm:cancelledReportValidPeriod (missing) and iwxxm:baseForecast</sch:assert>
+         <sch:assert test="( if( (iwxxm:baseForecast/@nilReason != 'http://codes.wmo.int/common/nil/missing' and (empty(@isCancelReport) or @isCancelReport = 'false')) and string-length(@translationFailedTAC) eq 0 ) then( exists(iwxxm:issueTime) and exists(iwxxm:aerodrome) and exists(iwxxm:validPeriod) and empty(iwxxm:cancelledReportValidPeriod) and exists(iwxxm:baseForecast) ) else( true() ) )">TAF.TAF-5: An ordinary report should have appropriately filled elements including iwxxm:issueTime, iwxxm:aerodrome, iwxxm:validPeriod, iwxxm:cancelledReportValidPeriod (missing) and iwxxm:baseForecast</sch:assert>
       </sch:rule>
    </sch:pattern>
    <sch:pattern id="TAF.TAF-1">

--- a/3.0.0RC2/taf.xsd
+++ b/3.0.0RC2/taf.xsd
@@ -62,11 +62,6 @@ Prevailing conditions and forecast changes differ in that the prevailing conditi
 						</annotation>
 					</element>
 				</sequence>
-				<attribute name="isNilReport" type="boolean">
-					<annotation>
-						<documentation>Indicates whether the report is a 'Nil' report (true) or not (false or empty).</documentation>
-					</annotation>
-				</attribute>
 				<attribute name="isCancelReport" type="boolean">
 					<annotation>
 						<documentation>Indicates whether the report is a 'CANCELLATION' report (true) which cancels a previously issued report or not (false or empty).</documentation>


### PR DESCRIPTION
Simplify by removing attribute isNilReason in METAR/SPECI and TAF and revised associated schemas, schematron rules, examples and TAC-to-XML Guidance.