### PR TITLE
Constrain IWXXM to 2D spatial CRSs Issue #140

### DIFF
--- a/IWXXM/rule/allowedSRSs.xml
+++ b/IWXXM/rule/allowedSRSs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<allowedSRSnames>
+  <ARP>
+    <srsName>urn:ogc:def:crs:EPSG::4326</srsName>
+    <srsName>http://www.opengis.net/def/crs/EPSG/0/4326</srsName>
+  </ARP>
+</allowedSRSnames>

--- a/IWXXM/rule/iwxxm.sch
+++ b/IWXXM/rule/iwxxm.sch
@@ -695,4 +695,10 @@
          <sch:assert test="following-sibling::*[1][self::iwxxm:extension] or not(following-sibling::*)">IWXXM.ExtensionAlwaysLast: Extension elements should be the last elements in their parents</sch:assert>
       </sch:rule>
    </sch:pattern>
+   <sch:pattern id="ARP-SRS-tests">
+      <sch:rule context="//aixm:AirportHeliportTimeSlice/aixm:ARP/aixm:ElevatedPoint/gml:pos">
+         <sch:assert test="ancestor-or-self::node()[@srsDimension='2']">srsDimension for ARP shall be set to 2</sch:assert>
+         <sch:assert test="ancestor-or-self::node()[@srsName = document('allowedSRSs.xml')//allowedSRSnames/ARP/srsName]">srsName not in ARP allowed list</sch:assert>
+      </sch:rule>
+   </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
#140 Unable to obtain full list of allowed srsNames for aixm:ARP.  Please review and update.