### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 /documentation export-ignore
 /externalSchema export-ignore
 /IWXXM/XMI export-ignore
-.* export-ignore
-*.xml export-ignore
-*.md export-ignore
-LATEST_VERSION export-ignore
+/.* export-ignore
+/*.xml export-ignore
+/*.md export-ignore
+/LATEST_VERSION export-ignore


### PR DESCRIPTION
This PR fixed the issue that .gitattributes export-ignore all XML files (including those under ./examples and ./html sub-directories) in the the release asset.  Once accepted, Release 3.0.0 will have to be regenerated and schemas.wmo.int re-populated with the XML files.
