### PR TITLE
Revised the two METAR examples to avoid schema validation error.

### DIFF
--- a/IWXXM/examples/metar-EDDF-runwaystate.xml
+++ b/IWXXM/examples/metar-EDDF-runwaystate.xml
@@ -3,7 +3,7 @@
     permissibleUsage="OPERATIONAL" reportStatus="NORMAL" xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0 https://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd">
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd">
     
     <iwxxm:issueTime>
         <gml:TimeInstant gml:id="uuid.ea606522-cf50-4874-adc3-83cc85b12b1c">
@@ -23,7 +23,7 @@
                     <aixm:ARP>
                         <aixm:ElevatedPoint axisLabels="Lat Long"
                             gml:id="uuid.7e308d55-3419-4169-8861-2a88af3b90ac" srsDimension="2"
-                            srsName="https://www.opengis.net/def/crs/EPSG/0/4326">
+                            srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                             <gml:pos>50.0464 8.5986</gml:pos>
                             <aixm:elevation uom="M">110</aixm:elevation>
                             <aixm:verticalDatum>EGM_96</aixm:verticalDatum>                            

--- a/IWXXM/examples/metar-LKKV.xml
+++ b/IWXXM/examples/metar-LKKV.xml
@@ -3,7 +3,7 @@
     permissibleUsage="OPERATIONAL" reportStatus="NORMAL" xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
     xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:iwxxm="http://icao.int/iwxxm/3.0"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://icao.int/iwxxm/3.0 https://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd">
+    xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd">
     <iwxxm:issueTime>
         <gml:TimeInstant gml:id="uuid.8053a919-45e1-4f22-9654-5c74032f4b64">
             <gml:timePosition>2007-07-25T12:00:00Z</gml:timePosition>
@@ -22,7 +22,7 @@
                     <aixm:ARP>
                         <aixm:ElevatedPoint axisLabels="Lat Long"
                             gml:id="uuid.8f22ff89-a47e-4eae-87c4-8ad604e3f57f" srsDimension="2"
-                            srsName="https://www.opengis.net/def/crs/EPSG/0/4326">
+                            srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
                             <gml:pos>50.20 12.90</gml:pos>
                         </aixm:ElevatedPoint>
                     </aixm:ARP>


### PR DESCRIPTION
This PR was made to correct a Travis CI error in which CRUX was unable to read the IWXXM schemas from https://schemas.wmo.int/iwxxm/3.0.0/iwxxm.xsd.  Interestingly when we changed the protocol from HTTPS to HTTP validation was successful.  More interestingly, oXygenXML also showed exactly the same behaviour.  Not sure what is happening, but would like to clean up the Build error in first place.