### PR TITLE
Replaced GML deprecated type "polygonPatches"

### DIFF
--- a/IWXXM/examples/airmet-A6-1a-TS.xml
+++ b/IWXXM/examples/airmet-A6-1a-TS.xml
@@ -81,7 +81,7 @@
 	                    <aixm:maximumLimit xsi:nil="true" nilReason="unknown"/>
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.626c2d10-d5ba-427e-a0c8-98949dd20a69" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:LinearRing>
@@ -95,7 +95,7 @@
                                                 </gml:LinearRing>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>

--- a/IWXXM/examples/sigmet-A6-1a-TS.xml
+++ b/IWXXM/examples/sigmet-A6-1a-TS.xml
@@ -83,7 +83,7 @@
                                     <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.e20caa4b-2b93-4d28-9b14-e04196314999" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -93,7 +93,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/IWXXM/examples/sigmet-A6-2-TC.xml
+++ b/IWXXM/examples/sigmet-A6-2-TC.xml
@@ -92,7 +92,7 @@
                                     <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:Ring>
@@ -109,7 +109,7 @@
                                                         </gml:Ring>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/IWXXM/examples/sigmet-VA-EGGX.xml
+++ b/IWXXM/examples/sigmet-VA-EGGX.xml
@@ -89,7 +89,7 @@
                                     <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.99f0ea38-755d-4435-b7c7-7cc5afcce237" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -97,7 +97,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>
@@ -119,7 +119,7 @@
                                 <aixm:AirspaceVolume gml:id="uuid.e985f12a-5e11-433c-aa5e-699eecb0c244">
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.a667da6f-fb8a-4029-93f3-509ab9408220" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -127,7 +127,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/IWXXM/examples/sigmet-multi-location-VA.xml
+++ b/IWXXM/examples/sigmet-multi-location-VA.xml
@@ -89,7 +89,7 @@
                                     <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.ca46d217-05d8-4f30-9ce0-b56b76af8d16" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -104,7 +104,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>
@@ -126,7 +126,7 @@
                                 <aixm:AirspaceVolume gml:id="uuid.908afad2-34ae-49bf-8f7a-866961c781f1">
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.c5464381-23a9-4641-8a79-df05e394302e" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -140,7 +140,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>
@@ -166,7 +166,7 @@
                                     <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.4a5d7c8d-9ab3-402a-86ff-3889823df192" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -180,7 +180,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>
@@ -198,7 +198,7 @@
                                 <aixm:AirspaceVolume gml:id="uuid.c8c2ee62-3075-4642-89b9-8a84f28e510a">
                                     <aixm:horizontalProjection>
                                         <aixm:Surface gml:id="uuid.c772f1bd-7684-4572-9907-7c742cc2013a" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                            <gml:polygonPatches>
+                                            <gml:patches>
                                                 <gml:PolygonPatch>
                                                     <gml:exterior>
                                                         <gml:LinearRing>
@@ -212,7 +212,7 @@
                                                         </gml:LinearRing>
                                                     </gml:exterior>
                                                 </gml:PolygonPatch>
-                                            </gml:polygonPatches>
+                                            </gml:patches>
                                         </aixm:Surface>
                                     </aixm:horizontalProjection>
                                 </aixm:AirspaceVolume>

--- a/IWXXM/examples/spacewx-A2-5.xml
+++ b/IWXXM/examples/spacewx-A2-5.xml
@@ -48,7 +48,7 @@
                         <aixm:AirspaceVolume gml:id="uuid.7138f8d1-9854-46cb-a1b1-9d96c5cee46f">
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.3b00652b-4bed-4655-959c-1c9efd431cac" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -65,7 +65,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
@@ -89,7 +89,7 @@
                         <aixm:AirspaceVolume gml:id="uuid.f0361bc9-3f9b-4418-9983-294395f54c7b">
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.19e4face-a4cf-4cc7-9331-4d032938e28e" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -106,7 +106,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
@@ -130,7 +130,7 @@
                         <aixm:AirspaceVolume gml:id="uuid.6dccaa55-f454-4269-a680-4173c386757f">
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.24ec6d9d-454a-4a53-be18-d3ff93a1a53a" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -147,7 +147,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>
@@ -171,7 +171,7 @@
                         <aixm:AirspaceVolume gml:id="uuid.731cc905-f97d-436c-bb63-a6023c27aa50">
                             <aixm:horizontalProjection>
                                 <aixm:Surface gml:id="uuid.e1e0500b-1251-40a7-a829-d09412ba1870" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                                    <gml:polygonPatches>
+                                    <gml:patches>
                                         <gml:PolygonPatch>
                                             <gml:exterior>
                                                 <gml:Ring>
@@ -188,7 +188,7 @@
                                                 </gml:Ring>
                                             </gml:exterior>
                                         </gml:PolygonPatch>
-                                    </gml:polygonPatches>
+                                    </gml:patches>
                                 </aixm:Surface>
                             </aixm:horizontalProjection>
                         </aixm:AirspaceVolume>

--- a/IWXXM/examples/tc-advisory-A2-2.xml
+++ b/IWXXM/examples/tc-advisory-A2-2.xml
@@ -55,7 +55,7 @@
                     <aixm:upperLimitReference>STD</aixm:upperLimitReference>
                     <aixm:horizontalProjection>
                         <aixm:Surface gml:id="uuid.62695824-f234-4618-b459-90bb795cde9a" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                            <gml:polygonPatches>
+                            <gml:patches>
                                 <gml:PolygonPatch>
                                     <gml:exterior>
                                         <gml:Ring>
@@ -72,7 +72,7 @@
                                         </gml:Ring>
                                     </gml:exterior>
                                 </gml:PolygonPatch>
-                            </gml:polygonPatches>
+                            </gml:patches>
                         </aixm:Surface>
                     </aixm:horizontalProjection>
                 </aixm:AirspaceVolume>


### PR DESCRIPTION
Replaced use of gml:polygonPatches with gml:patches.