### PR TITLE
Update SIGMET and AIRMET stationary movement

### DIFF
--- a/IWXXM/airmet.xsd
+++ b/IWXXM/airmet.xsd
@@ -154,12 +154,12 @@ TC TOP (ABV and BLW) conditions are represented by the vertical component of the
 					</element>
 					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>The expected direction of movement of a meteorological condition. Stationary phenomenon shall be denoted with both iwxxm:directionOfMotion and iwxxm:speedOfMotion absent.  Direction of motion to shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
+							<documentation>The expected direction of movement of a meteorological condition. Stationary phenomenon shall be denoted with an empty iwxxm:directionOfMotion with nilReason "http://codes.wmo.int/common/nil/inapplicable" and iwxxm:speedOfMotion of 0. Direction of motion to shall be given in degrees from true North. Plane angle unit of measure (uom) is "deg".</documentation>
 						</annotation>
 					</element>
 					<element name="speedOfMotion" type="gml:SpeedType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>The expected speed of movement of a meteorological condition. Stationary phenomenon shall be denoted with both iwxxm:directionOfMotion and iwxxm:speedOfMotion absent. Speed of movement shall be given in either "km/h" or "[kn_i]" (knot).</documentation>
+							<documentation>The expected speed of movement of a meteorological condition. Stationary phenomenon shall be denoted with an empty iwxxm:directionOfMotion with nilReason "http://codes.wmo.int/common/nil/inapplicable" and iwxxm:speedOfMotion of 0. Speed of movement shall be given in either "km/h" or "[kn_i]" (knot).</documentation>
 						</annotation>
 					</element>
 					<element name="cloudBase" type="gml:LengthType" minOccurs="0" maxOccurs="1">

--- a/IWXXM/sigmet.xsd
+++ b/IWXXM/sigmet.xsd
@@ -112,14 +112,14 @@ In cases where the position covers an entire FIR or CTA, ("ENTIRE CTA or ENTIRE 
 					</element>
 					<element nillable="true" name="directionOfMotion" type="iwxxm:AngleWithNilReasonType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>This element refers to the expected direction of movement which the phenomenon is moving towards, .e.g, "moving east". Stationary phenomenon shall be denoted with both iwxxm:directionOfMotion and iwxxm:speedOfMotion absent.
+							<documentation>This element refers to the expected direction of movement which the phenomenon is moving towards, .e.g, "moving east". Stationary phenomenon shall be denoted with an empty iwxxm:directionOfMotion with nilReason "http://codes.wmo.int/common/nil/inapplicable" and iwxxm:speedOfMotion of 0.
 
 This element value is given in degrees from true North. Plane angle unit of measure (uom) is "deg". </documentation>
 						</annotation>
 					</element>
 					<element name="speedOfMotion" type="gml:SpeedType" minOccurs="0" maxOccurs="1">
 						<annotation>
-							<documentation>The expected speed of movement of a meteorological condition. Stationary phenomenon shall be denoted with both iwxxm:directionOfMotion and iwxxm:speedOfMotion absent.
+							<documentation>The expected speed of movement of a meteorological condition. Stationary phenomenon shall be denoted with an empty iwxxm:directionOfMotion with nilReason "http://codes.wmo.int/common/nil/inapplicable" and iwxxm:speedOfMotion of 0.
 
 speedOfMotion can be provided in either two units of measures: "km/h" or "[kn_i]" (knots).</documentation>
 						</annotation>


### PR DESCRIPTION
Align the documentation of directionOfMotion and speedOfMotion with TAC-to-XML-Guidance.txt. Specific values should report the stationary movement. It allows for distinguishing between the stationary movement and the case when no movement is reported. The case when no movement is reported can occur when SIGMET is created from advisory, and the observation does not affect the FIR; only the +6-hour forecast affects the FIR. The movement is forecasted only for the observation in the advisory.

Related to #250