### PR TITLE
Update metar-A3-1.xml

### DIFF
--- a/IWXXM/examples/metar-A3-1.xml
+++ b/IWXXM/examples/metar-A3-1.xml
@@ -98,10 +98,10 @@
     </iwxxm:observation>
 
     <iwxxm:trendForecast>
-        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING">
+        <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING" cloudAndVisibilityOK="false">
             <iwxxm:phenomenonTime>
                 <gml:TimePeriod gml:id="uuid.819b0c7a-133f-4029-b1d9-451be77e3c5f">
-                    <gml:beginPosition>2012-08-22T16:30:00Z</gml:beginPosition>
+                    <gml:beginPosition indeterminatePosition="before">2012-08-22T16:30:00Z</gml:beginPosition>
                     <gml:endPosition>2012-08-22T17:00:00Z</gml:endPosition>
                 </gml:TimePeriod>
             </iwxxm:phenomenonTime>


### PR DESCRIPTION
BECMG TL1700: FM not specified so beginPosition should be noted with attribute  indeterminatePosition="before" CAVOK is not specified so its not OK
MeteorologicalAerodromeTrendForecast -> cloudAndVisibilityOK="false"

### Making a pull request
In making a pull request, please make sure that both the model under wmo-im/iwxxm-modelling and wmo-im/iwxxm are sychnchronized, and correct version of model's exported XMI file and HTML documentation are in wmo-im/iwxxm. 
